### PR TITLE
Sprint 3.33 S2: harvester kernel + scoring patch + #143 fix

### DIFF
--- a/dashboard/app/pages/signals.vue
+++ b/dashboard/app/pages/signals.vue
@@ -95,15 +95,47 @@ async function accept(signal: LeadSignal) {
 async function dismiss(signal: LeadSignal, reason: LeadDismissalReason) {
   if (busyIds.value.has(signal.resourceName)) return
   busyIds.value.add(signal.resourceName)
+
+  // Optimistic update — move the contact from candidates/backlog to dismissed
+  // BEFORE the network round-trip. Fixes #143: without this, the contact is
+  // still visible in the list while refresh() is in flight, so a second
+  // Dismiss click lands in the `busyIds` guard and silently no-ops.
+  // Reassign `data.value` with a new object per Nuxt useFetch gotcha #147 —
+  // nested-property mutation can miss reactivity after hydration.
+  const snapshot = data.value
+  if (snapshot) {
+    const nowIso = new Date().toISOString()
+    const nextSignal: LeadSignal = {
+      ...signal,
+      stage: 'dismissed',
+      dismissal: { reason, note: '', dismissedAt: nowIso },
+    }
+    data.value = {
+      ...snapshot,
+      candidates: snapshot.candidates.filter((s: LeadSignal) => s.resourceName !== signal.resourceName),
+      backlog: snapshot.backlog.filter((s: LeadSignal) => s.resourceName !== signal.resourceName),
+      dismissed: [nextSignal, ...snapshot.dismissed.filter((s: LeadSignal) => s.resourceName !== signal.resourceName)],
+      stats: {
+        ...snapshot.stats,
+        candidates: Math.max(0, snapshot.stats.candidates - (signal.stage === 'candidate' ? 1 : 0)),
+        dismissed: snapshot.stats.dismissed + (signal.stage === 'dismissed' ? 0 : 1),
+      },
+    }
+  }
+
   try {
     await $fetch('/api/signals/dismiss', {
       method: 'POST',
       body: { resourceName: signal.resourceName, reason, note: '' },
     })
-    await refresh()
+    // Post-write refresh reconciles any server-computed fields (rank, etc.)
+    // but the user's next interaction is no longer blocked by it.
+    refresh().catch(e => console.warn('Signals refresh after dismiss failed', e))
   } catch (e) {
     console.error('Dismiss failed', e)
     alert('Dismiss failed — check console')
+    // Restore the snapshot so the UI reflects the actual server state.
+    if (snapshot) data.value = snapshot
   } finally {
     busyIds.value.delete(signal.resourceName)
   }

--- a/followup_scorer.py
+++ b/followup_scorer.py
@@ -19,6 +19,20 @@ from typing import Optional
 
 from config import (
     DATA_DIR,
+    FOLLOWUP_BEEPER_AWAITING_MY_REPLY,
+    FOLLOWUP_BEEPER_BUSINESS_HOURS,
+    FOLLOWUP_BEEPER_BUSINESS_HOURS_RATIO,
+    FOLLOWUP_BEEPER_BUSINESS_KEYWORDS,
+    FOLLOWUP_BEEPER_INBOUND_HEAVY,
+    FOLLOWUP_BEEPER_INBOUND_HEAVY_DELTA,
+    FOLLOWUP_BEEPER_KPI_FILE,
+    FOLLOWUP_BEEPER_LONG_SILENCE_DAYS,
+    FOLLOWUP_BEEPER_LONG_SILENCE_PENALTY,
+    FOLLOWUP_BEEPER_MAX,
+    FOLLOWUP_BEEPER_MIN,
+    FOLLOWUP_BEEPER_MULTICHANNEL,
+    FOLLOWUP_BEEPER_STALE_SENT_MIN_COUNT,
+    FOLLOWUP_BEEPER_STALE_SENT_PENALTY,
     FOLLOWUP_COMPLETENESS_WEIGHT,
     FOLLOWUP_EXEC_TITLE_BONUS,
     FOLLOWUP_EXEC_TITLE_KEYWORDS,
@@ -34,6 +48,12 @@ from config import (
     FOLLOWUP_PERSONAL_PENALTY,
     FOLLOWUP_SCORES_FILE,
     FOLLOWUP_TOP_N,
+)
+from harvester.scoring_signals import (
+    BeeperWeights,
+    ContactKPI,
+    compute_beeper_bonus,
+    load_kpis_from_json,
 )
 from interaction_scanner import _classify_url
 
@@ -53,6 +73,44 @@ def load_linkedin_signals(path: Optional[Path] = None) -> dict[str, dict]:
     except (json.JSONDecodeError, KeyError) as e:
         logger.warning(f"FollowUp: Failed to parse linkedin_signals.json: {e}")
         return {}
+
+
+def load_contact_kpis(path: Optional[Path] = None) -> dict[str, ContactKPI]:
+    """Load ContactKPI rollups from local JSON file, keyed by resourceName.
+
+    Returns empty dict if file missing or schema_version mismatches —
+    scoring falls back gracefully to pre-Beeper behaviour with
+    score_beeper=0 for every contact. Harvester hasn't run yet → no
+    regression; harvester ran but crashed mid-write → we ignore the
+    broken file rather than scoring on half-baked data.
+    """
+    if path is None:
+        path = FOLLOWUP_BEEPER_KPI_FILE
+    try:
+        kpis = load_kpis_from_json(path)
+        if kpis:
+            logger.info(f"FollowUp: loaded {len(kpis)} ContactKPI records from {path}")
+        return kpis
+    except Exception as e:
+        logger.warning(f"FollowUp: failed to load contact_kpis.json: {e}")
+        return {}
+
+
+_BEEPER_WEIGHTS = BeeperWeights(
+    awaiting_my_reply=FOLLOWUP_BEEPER_AWAITING_MY_REPLY,
+    multichannel=FOLLOWUP_BEEPER_MULTICHANNEL,
+    business_keywords=FOLLOWUP_BEEPER_BUSINESS_KEYWORDS,
+    business_hours=FOLLOWUP_BEEPER_BUSINESS_HOURS,
+    inbound_heavy=FOLLOWUP_BEEPER_INBOUND_HEAVY,
+    stale_sent_penalty=FOLLOWUP_BEEPER_STALE_SENT_PENALTY,
+    long_silence_penalty=FOLLOWUP_BEEPER_LONG_SILENCE_PENALTY,
+    cap_max=FOLLOWUP_BEEPER_MAX,
+    cap_min=FOLLOWUP_BEEPER_MIN,
+    business_hours_ratio_threshold=FOLLOWUP_BEEPER_BUSINESS_HOURS_RATIO,
+    inbound_heavy_delta=FOLLOWUP_BEEPER_INBOUND_HEAVY_DELTA,
+    stale_sent_min_count=FOLLOWUP_BEEPER_STALE_SENT_MIN_COUNT,
+    long_silence_days=FOLLOWUP_BEEPER_LONG_SILENCE_DAYS,
+)
 
 
 @dataclass
@@ -85,6 +143,7 @@ class FollowUpScore:
     score_completeness: float
     score_exec: float
     personal_multiplier: float
+    score_beeper: float                        # ContactKPI-driven bonus (#150), capped [FOLLOWUP_BEEPER_MIN, FOLLOWUP_BEEPER_MAX]
     score_total: float
     # Contact metadata
     org: str
@@ -94,6 +153,13 @@ class FollowUpScore:
     # Set after scoring
     rank: int = 0
     followup_prompt: Optional[str] = None
+    # Beeper metadata (defaults = "no Beeper signal") — placed at end to preserve
+    # the dataclass non-default-then-default ordering.
+    beeper_channel_primary: Optional[str] = None
+    beeper_awaiting_reply_side: Optional[str] = None
+    beeper_messages_30d_in: int = 0
+    beeper_messages_30d_out: int = 0
+    beeper_channels_30d: int = 0
 
 
 def _is_exec_title(title: str, headline: str, current_role: str) -> bool:
@@ -192,6 +258,7 @@ def score_contacts(
     interactions: dict[str, dict],
     contact_emails: dict[str, set[str]],
     linkedin_signals: dict[str, dict],
+    contact_kpis: Optional[dict[str, ContactKPI]] = None,
     top_n: int = FOLLOWUP_TOP_N,
     min_interactions: int = FOLLOWUP_MIN_INTERACTIONS,
     min_months: float = FOLLOWUP_MIN_MONTHS,
@@ -199,7 +266,10 @@ def score_contacts(
     """Score all contacts and return top_n sorted by score_total descending.
 
     LinkedIn job_change signals bypass the min_months and min_interactions filters.
+    If contact_kpis is provided, each contact's multi-channel Beeper activity
+    contributes an additive bonus via compute_beeper_bonus() (#150).
     """
+    contact_kpis = contact_kpis or {}
     today = datetime.now(timezone.utc)
     contacts_by_rn = {c.get("resourceName", ""): c for c in contacts}
     candidates: list[FollowUpScore] = []
@@ -277,7 +347,29 @@ def score_contacts(
         score_exec = FOLLOWUP_EXEC_TITLE_BONUS if is_exec else 0.0
         personal_multiplier = FOLLOWUP_PERSONAL_PENALTY if is_likely_personal else 1.0
 
-        base_score = score_interaction + score_linkedin + score_completeness + score_exec
+        # Beeper bonus — 0 if no KPI data (graceful fallback when harvester
+        # hasn't run yet or contact has no cross-channel activity)
+        kpi = contact_kpis.get(rn)
+        if kpi:
+            score_beeper = compute_beeper_bonus(kpi, _BEEPER_WEIGHTS, as_of=today)
+            w30 = kpi.windows.get("30d")
+            beeper_channel_primary = kpi.channel_primary
+            beeper_awaiting_side = kpi.last_awaiting_reply_side
+            beeper_msgs_in = w30.messages_in if w30 else 0
+            beeper_msgs_out = w30.messages_out if w30 else 0
+            beeper_channels = len(w30.channels) if w30 else 0
+        else:
+            score_beeper = 0.0
+            beeper_channel_primary = None
+            beeper_awaiting_side = None
+            beeper_msgs_in = 0
+            beeper_msgs_out = 0
+            beeper_channels = 0
+
+        base_score = (
+            score_interaction + score_linkedin + score_completeness
+            + score_exec + score_beeper
+        )
         score_total = base_score * personal_multiplier
 
         # LinkedIn metadata
@@ -310,11 +402,17 @@ def score_contacts(
             score_completeness=score_completeness,
             score_exec=score_exec,
             personal_multiplier=personal_multiplier,
+            score_beeper=round(score_beeper, 1),
             score_total=round(score_total, 1),
             org=org,
             title=title,
             emails=list(emails),
             urls=urls,
+            beeper_channel_primary=beeper_channel_primary,
+            beeper_awaiting_reply_side=beeper_awaiting_side,
+            beeper_messages_30d_in=beeper_msgs_in,
+            beeper_messages_30d_out=beeper_msgs_out,
+            beeper_channels_30d=beeper_channels,
         ))
 
     # Sort by score descending, take top N
@@ -346,12 +444,20 @@ def build_followup_scores_json(scored_list: list[FollowUpScore]) -> dict:
                 "linkedin": s.score_linkedin,
                 "completeness": s.score_completeness,
                 "exec_bonus": s.score_exec,
+                "beeper": s.score_beeper,
                 "personal_multiplier": s.personal_multiplier,
             },
             "flags": {
                 "is_exec": s.is_exec,
                 "is_likely_personal": s.is_likely_personal,
             },
+            "beeper": {
+                "channel_primary": s.beeper_channel_primary,
+                "awaiting_reply_side": s.beeper_awaiting_reply_side,
+                "messages_30d_in": s.beeper_messages_30d_in,
+                "messages_30d_out": s.beeper_messages_30d_out,
+                "channels_30d": s.beeper_channels_30d,
+            } if s.score_beeper != 0 else None,
             "interaction": {
                 "last_date": s.last_date,
                 "months_gap": s.months_gap,
@@ -389,6 +495,10 @@ def build_followup_scores_json(scored_list: list[FollowUpScore]) -> dict:
         "no_linkedin": sum(1 for s in scored_list if not s.linkedin_signal),
         "avg_completeness": round(
             sum(s.completeness for s in scored_list) / len(scored_list), 1
+        ) if scored_list else 0,
+        "beeper_enriched": sum(1 for s in scored_list if s.score_beeper != 0),
+        "avg_beeper_bonus": round(
+            sum(s.score_beeper for s in scored_list) / len(scored_list), 1
         ) if scored_list else 0,
     }
 

--- a/harvester/beeper_client.py
+++ b/harvester/beeper_client.py
@@ -1,0 +1,692 @@
+"""
+Beeper Desktop API — HTTP client + ChannelReader wrapper.
+
+Thin transport layer over `beeper_oauth.get_or_create_token`. Stdlib-only
+(urllib), matches the ChannelReader protocol in docs/schemas/interaction.md
+so `pipeline.py` can treat it uniformly alongside `IMessageReader`.
+
+One `BeeperClient` emits records across all Beeper-attached networks
+(WhatsApp, Signal, Messenger, LinkedIn DM, Telegram, Instagram, X,
+Discord, …) — so its `channel` attribute is per-record, not per-reader.
+
+Key behaviours:
+- `available()` probes `/v1/info` with a 2s timeout (no auth required).
+- `harvest(since, until)` paginates `/v1/chats` then
+  `/v1/chats/{id}/messages` with cursor support, normalizes each message
+  into an InteractionRecord, and throttles to 1 req/sec to stay under
+  Beeper's (undocumented) rate ceiling.
+- `401 Unauthorized` triggers one forced re-auth, then a single retry.
+  A second 401 raises — we don't want the harvester silently skipping
+  an entire cadence when credentials are dead.
+
+Run inline self-test (offline — does not touch Beeper):
+    python -m harvester.beeper_client
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterator, Optional
+
+from harvester.beeper_oauth import (
+    DEFAULT_ISSUER,
+    BeeperToken,
+    get_or_create_token,
+    is_beeper_reachable,
+)
+
+logger = logging.getLogger("contacts-refiner.beeper_client")
+
+HTTP_TIMEOUT_SECONDS = 15
+REQUEST_INTERVAL_SECONDS = 1.0  # polite throttle per beeper-api-reference.md
+PAGE_LIMIT = 100                # per-page cap for /chats + /messages
+MESSAGE_SUMMARY_MAX = 500
+
+# Map Beeper network identifiers → interaction.md channel vocabulary.
+# Beeper's /v1/accounts returns `networkID` like "whatsapp", "signal",
+# "facebook" (Messenger), "linkedin", "telegram", "instagram", "x",
+# "discord". The mapping is mostly 1:1; the exceptions are normalized
+# here so pipeline.py never sees a raw Beeper identifier leaking into
+# `channel`.
+NETWORK_CHANNEL_MAP: dict[str, str] = {
+    "whatsapp": "whatsapp",
+    "signal": "signal",
+    "facebook": "messenger",
+    "messenger": "messenger",
+    "linkedin": "linkedin_dm",
+    "telegram": "telegram",
+    "instagram": "instagram",
+    "x": "x",
+    "twitter": "x",
+    "discord": "discord",
+    "slack": "slack",
+    "imessage": "imessage",  # Beeper can mirror iMessage; reader prefers direct chat.db
+}
+
+
+# ── data shapes ───────────────────────────────────────────────────────────
+
+@dataclass
+class BeeperClientConfig:
+    """Instance config. All fields have sensible defaults."""
+    issuer: str = DEFAULT_ISSUER
+    page_limit: int = PAGE_LIMIT
+    request_interval_seconds: float = REQUEST_INTERVAL_SECONDS
+    summary_max_chars: int = MESSAGE_SUMMARY_MAX
+    # When True, skip the iMessage channel from Beeper output — direct
+    # chat.db reader handles it better (NSArchiver decoding, group chat
+    # metadata). Avoids duplicate records for the same message.
+    skip_imessage: bool = True
+    # When True, skip group chats. Matches iMessage reader default False
+    # inverted — groups are high-volume + low-signal for CRM.
+    skip_group_chats: bool = False
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+def _truncate_summary(body: Optional[str], max_chars: int) -> str:
+    """Apply interaction.md §summary rules: collapse whitespace, cap length.
+
+    URL stripping is intentionally NOT done here — Beeper returns message
+    text already in plain form, and the `(domain)` transformation from
+    interaction.md is expensive to get right (false-positive on code
+    snippets, IPv4 literals, etc.). Pipeline.py can apply it post-hoc if
+    needed; for now keep the summary closer to the source.
+    """
+    if body is None:
+        return ""
+    clean = " ".join(str(body).split())
+    if not clean:
+        return ""
+    if len(clean) <= max_chars:
+        return clean
+    return clean[: max_chars - 1] + "…"
+
+
+def _hash_interaction_id(
+    channel: str, thread_id: str, ts_iso: str, direction: str, external_id: str,
+) -> str:
+    """sha256 truncated to 16 hex chars. Matches imessage_reader._hash scheme
+    so interactionIds are comparable across readers when the same message
+    appears via multiple paths."""
+    key = f"{channel}|{thread_id}|{ts_iso}|{direction}|{external_id}"
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    s = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _format_iso(dt: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+# ── client ────────────────────────────────────────────────────────────────
+
+class BeeperClient:
+    """HTTP client + ChannelReader for Beeper Desktop.
+
+    Thread-unsafe by design — harvester calls are single-threaded. The
+    token is refreshed lazily, so a long-running harvest that crosses an
+    expiry boundary still works.
+    """
+
+    channel = "beeper"  # per-reader channel; real per-record channel comes from network
+
+    def __init__(self, config: Optional[BeeperClientConfig] = None):
+        self.config = config or BeeperClientConfig()
+        self._token: Optional[BeeperToken] = None
+        self._last_request_ts: float = 0.0
+        self._accounts_cache: Optional[list[dict]] = None
+
+    # ── ChannelReader protocol ──────────────────────────────────────────
+
+    def available(self) -> bool:
+        """Non-auth reachability probe. Fast — 2s timeout in the helper."""
+        if not is_beeper_reachable(self.config.issuer):
+            logger.info(
+                "BeeperClient: Desktop API not reachable at %s — skipping",
+                self.config.issuer,
+            )
+            return False
+        return True
+
+    def harvest(
+        self,
+        since: Optional[datetime] = None,
+        until: Optional[datetime] = None,
+    ) -> Iterator[dict]:
+        """Yield InteractionRecord dicts for messages in [since, until).
+
+        Walks /v1/chats, then per-chat /v1/chats/{id}/messages. Ordering
+        within a chat follows Beeper's response (newest-first typically),
+        but callers should not rely on global ordering — pipeline.py
+        sorts before writing.
+        """
+        if not self.available():
+            return
+
+        token = self._ensure_token()
+        accounts_by_id = self._build_account_index()
+
+        for chat in self._iter_chats(token):
+            chat_id = chat.get("id") or chat.get("chatID") or ""
+            if not chat_id:
+                continue
+            account_id = chat.get("accountID") or chat.get("accountId") or ""
+            network_id = (
+                chat.get("networkID")
+                or chat.get("network")
+                or accounts_by_id.get(account_id, {}).get("networkID")
+                or ""
+            ).lower()
+
+            if self.config.skip_imessage and network_id == "imessage":
+                continue
+
+            is_group = bool(chat.get("isGroupChat") or chat.get("isGroup"))
+            if self.config.skip_group_chats and is_group:
+                continue
+
+            channel = NETWORK_CHANNEL_MAP.get(network_id, network_id or "beeper")
+
+            for message in self._iter_messages(token, chat_id, since=since, until=until):
+                record = self._message_to_record(
+                    message=message,
+                    chat=chat,
+                    channel=channel,
+                    network_id=network_id,
+                    is_group=is_group,
+                )
+                if record is None:
+                    continue
+                yield record
+
+    # ── HTTP primitives ─────────────────────────────────────────────────
+
+    def _ensure_token(self) -> BeeperToken:
+        if self._token is None or self._token.is_expired():
+            self._token = get_or_create_token(issuer=self.config.issuer)
+        return self._token
+
+    def _throttle(self) -> None:
+        elapsed = time.monotonic() - self._last_request_ts
+        interval = self.config.request_interval_seconds
+        if elapsed < interval:
+            time.sleep(interval - elapsed)
+        self._last_request_ts = time.monotonic()
+
+    def _get_json(self, path: str, params: Optional[dict] = None) -> dict:
+        """GET a JSON endpoint with 401-once-retry.
+
+        Raises on non-2xx other than 401 (which triggers re-auth + single
+        retry). The retry explicitly forces a fresh token via
+        `get_or_create_token(force_new=True)` rather than the lazy
+        refresh path, since a 401 likely means the refresh_token is
+        also stale.
+        """
+        self._throttle()
+        token = self._ensure_token()
+        url = self._build_url(path, params)
+
+        for attempt in (0, 1):
+            req = urllib.request.Request(
+                url,
+                headers={
+                    "Authorization": f"Bearer {token.access_token}",
+                    "Accept": "application/json",
+                },
+                method="GET",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:
+                    return json.loads(resp.read().decode("utf-8"))
+            except urllib.error.HTTPError as e:
+                if e.code == 401 and attempt == 0:
+                    logger.info("BeeperClient: 401 on %s — forcing re-auth", path)
+                    self._token = get_or_create_token(
+                        issuer=self.config.issuer, force_new=True,
+                    )
+                    token = self._token
+                    continue
+                body = e.read().decode("utf-8", errors="replace") if e.fp else ""
+                raise RuntimeError(
+                    f"Beeper API error {e.code} on {path}: {body[:200]}"
+                ) from e
+
+        # Unreachable — the loop either returns or raises.
+        raise RuntimeError(f"Beeper API: exhausted retries on {path}")
+
+    def _build_url(self, path: str, params: Optional[dict]) -> str:
+        base = self.config.issuer.rstrip("/") + path
+        if not params:
+            return base
+        filtered = {k: v for k, v in params.items() if v is not None}
+        if not filtered:
+            return base
+        return base + "?" + urllib.parse.urlencode(filtered, doseq=False)
+
+    # ── endpoint wrappers ───────────────────────────────────────────────
+
+    def _build_account_index(self) -> dict[str, dict]:
+        """Fetch /v1/accounts once per harvest — used to attach
+        networkID to chat records that don't self-report it."""
+        if self._accounts_cache is None:
+            try:
+                data = self._get_json("/v1/accounts")
+            except RuntimeError as e:
+                logger.warning("BeeperClient: /v1/accounts failed: %s", e)
+                self._accounts_cache = []
+                return {}
+            # Response may be a list or {accounts:[...]}
+            self._accounts_cache = (
+                data if isinstance(data, list) else data.get("accounts") or []
+            )
+        return {
+            (a.get("accountID") or a.get("id") or ""): a
+            for a in self._accounts_cache
+        }
+
+    def _iter_chats(self, token: BeeperToken) -> Iterator[dict]:
+        """Paginate /v1/chats across all accounts.
+
+        Beeper's pagination uses a `cursor` token in the response (the
+        spec calls it `nextCursor`). We keep calling until the cursor
+        disappears or we've seen an empty page.
+        """
+        cursor: Optional[str] = None
+        while True:
+            params = {"limit": self.config.page_limit}
+            if cursor:
+                params["cursor"] = cursor
+            data = self._get_json("/v1/chats", params=params)
+            items = self._extract_items(data, key="chats")
+            if not items:
+                return
+            for item in items:
+                yield item
+            cursor = (
+                data.get("nextCursor")
+                or data.get("next_cursor")
+                or data.get("cursor")
+            )
+            if not cursor:
+                return
+
+    def _iter_messages(
+        self,
+        token: BeeperToken,
+        chat_id: str,
+        *,
+        since: Optional[datetime],
+        until: Optional[datetime],
+    ) -> Iterator[dict]:
+        """Paginate /v1/chats/{id}/messages within [since, until).
+
+        Beeper returns messages newest-first per page. We paginate backward
+        via the response cursor until we cross `since`, then stop. This
+        is more efficient than fetching all history every run.
+        """
+        cursor: Optional[str] = None
+        while True:
+            params = {"limit": self.config.page_limit}
+            if cursor:
+                params["cursor"] = cursor
+            path = f"/v1/chats/{urllib.parse.quote(chat_id, safe=':!@')}/messages"
+            try:
+                data = self._get_json(path, params=params)
+            except RuntimeError as e:
+                # Per-chat failures are non-fatal — log and move on. A
+                # wedged chat shouldn't halt the whole harvest.
+                logger.warning(
+                    "BeeperClient: messages for chat %s failed: %s", chat_id, e,
+                )
+                return
+            items = self._extract_items(data, key="messages")
+            if not items:
+                return
+
+            crossed_since = False
+            for msg in items:
+                ts = _parse_iso(
+                    msg.get("timestamp") or msg.get("createdAt") or msg.get("sentAt")
+                )
+                if ts is None:
+                    # Can't window-filter without a timestamp; skip but
+                    # don't halt — some edge messages (deleted?) may
+                    # arrive without one.
+                    continue
+                if until is not None and ts >= until:
+                    continue
+                if since is not None and ts < since:
+                    crossed_since = True
+                    continue
+                yield msg
+
+            if crossed_since:
+                # We've paginated into pre-since territory — no need to
+                # keep fetching older pages.
+                return
+            cursor = (
+                data.get("nextCursor")
+                or data.get("next_cursor")
+                or data.get("cursor")
+            )
+            if not cursor:
+                return
+
+    @staticmethod
+    def _extract_items(data: dict | list, *, key: str) -> list[dict]:
+        """Beeper endpoints vary between returning `[...]` and `{key: [...]}`.
+
+        Absorb the variance in one place so the walker loops stay simple.
+        """
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            val = data.get(key) or data.get("items") or data.get("data")
+            if isinstance(val, list):
+                return val
+        return []
+
+    # ── record normalization ────────────────────────────────────────────
+
+    def _message_to_record(
+        self,
+        *,
+        message: dict,
+        chat: dict,
+        channel: str,
+        network_id: str,
+        is_group: bool,
+    ) -> Optional[dict]:
+        """Map a Beeper message dict → InteractionRecord per interaction.md.
+
+        Returns None on structural mismatch (missing timestamp, missing
+        both sender + chat id) so pipeline.py can skip without special-case
+        handling.
+        """
+        ts = _parse_iso(
+            message.get("timestamp") or message.get("createdAt") or message.get("sentAt")
+        )
+        if ts is None:
+            return None
+        ts_iso = _format_iso(ts)
+
+        # Direction: Beeper tags own messages via `isSender`/`isFromMe`.
+        is_from_me = bool(
+            message.get("isSender")
+            or message.get("isFromMe")
+            or message.get("senderSelf")
+        )
+        direction = "outbound" if is_from_me else "inbound"
+
+        chat_id = chat.get("id") or chat.get("chatID") or ""
+        thread_id = f"beeper:{chat_id}" if chat_id else f"beeper:{network_id}:unknown"
+
+        external_id = (
+            message.get("id")
+            or message.get("messageID")
+            or message.get("externalID")
+            or ""
+        )
+
+        body = (
+            message.get("text")
+            or message.get("body")
+            or message.get("content")
+            or ""
+        )
+        summary = _truncate_summary(body, self.config.summary_max_chars)
+        if not summary:
+            # Channel-specific placeholder per interaction.md §summary rule 5.
+            if message.get("attachments") or message.get("assetURLs"):
+                summary = "[attachment]"
+            elif message.get("reactions"):
+                summary = "[reaction]"
+            else:
+                summary = "[empty]"
+
+        # Match candidates: Beeper exposes sender handle + chat participants.
+        match_candidates: dict[str, list[str]] = {
+            "emails": [],
+            "phones": [],
+            "handles": [],
+        }
+        participants: list[dict] = []
+
+        sender = message.get("sender") or {}
+        sender_handle = (
+            sender.get("handle")
+            or sender.get("id")
+            or message.get("senderID")
+            or ""
+        )
+        sender_name = sender.get("fullName") or sender.get("name") or ""
+        if sender_handle and not is_from_me:
+            self._add_candidate(match_candidates, sender_handle, network_id, chat_id)
+            participants.append({
+                "kind": self._classify_handle(sender_handle),
+                "value": sender_handle,
+                "name": sender_name or None,
+                "self": False,
+            })
+
+        for p in chat.get("participants") or []:
+            if p.get("isSelf"):
+                continue
+            handle = p.get("handle") or p.get("id") or ""
+            if not handle or handle == sender_handle:
+                continue
+            self._add_candidate(match_candidates, handle, network_id, chat_id)
+            participants.append({
+                "kind": self._classify_handle(handle),
+                "value": handle,
+                "name": p.get("fullName") or p.get("name"),
+                "self": False,
+            })
+
+        interaction_id = _hash_interaction_id(
+            channel, thread_id, ts_iso, direction, external_id or sender_handle,
+        )
+
+        return {
+            "interactionId": interaction_id,
+            "contactId": None,
+            "matchCandidates": match_candidates,
+            "channel": channel,
+            "direction": direction,
+            "threadId": thread_id,
+            "timestamp": ts_iso,
+            "subject": message.get("subject"),
+            "summary": summary,
+            "fullTextRef": None,
+            "participants": participants,
+            "metadata": {
+                "source": "beeper",
+                "sourceVersion": "beeper_client@1",
+                "beeperChatId": chat_id,
+                "beeperNetwork": network_id or None,
+                "beeperMessageId": external_id or None,
+                "isRead": bool(message.get("isRead")),
+                "readAt": message.get("readAt"),
+                "reactionCount": len(message.get("reactions") or []),
+                "hasAttachments": bool(message.get("attachments") or message.get("assetURLs")),
+                "isGroupChat": is_group,
+            },
+        }
+
+    @staticmethod
+    def _classify_handle(handle: str) -> str:
+        if "@" in handle and not handle.startswith("@"):
+            return "email"
+        if any(c.isdigit() for c in handle) and handle.lstrip("+").replace("-", "").replace(" ", "").isdigit():
+            return "phone"
+        return "handle"
+
+    @staticmethod
+    def _add_candidate(
+        cands: dict[str, list[str]], handle: str, network_id: str, chat_id: str,
+    ) -> None:
+        """Route a raw Beeper handle into the right candidate bucket.
+
+        Matrix room IDs (`!room:domain`) go into `handles`; email-shaped
+        strings into `emails`; phone-shaped into `phones`. Also stamps a
+        network-qualified composite into `handles` so ContactMatcher's
+        cache can do exact lookups like `beeper:whatsapp:+421...`.
+        """
+        if "@" in handle and not handle.startswith("@"):
+            cands["emails"].append(handle.lower())
+        elif handle.startswith("+") or handle.lstrip("+").replace("-", "").replace(" ", "").isdigit():
+            # Leave phone normalization to ContactMatcher.normalize_phone;
+            # just surface the raw string here.
+            cands["phones"].append(handle)
+        else:
+            cands["handles"].append(handle)
+
+        if network_id:
+            cands["handles"].append(f"beeper:{network_id}:{handle}")
+        if chat_id and chat_id.startswith("!"):
+            # Matrix room id — useful for cache-keying across members
+            cands["handles"].append(f"beeper_room:{chat_id}")
+
+
+# ── CLI self-test ─────────────────────────────────────────────────────────
+
+def _run_self_test() -> None:
+    """Offline-only tests. Covers normalization + URL construction without
+    touching the Beeper API."""
+    print("BeeperClient self-test (offline)…")
+
+    # summary truncation
+    assert _truncate_summary("a b\n\nc  d" * 50, 20).endswith("…")
+    assert _truncate_summary("", 20) == ""
+    assert _truncate_summary(None, 20) == ""
+    assert _truncate_summary("hello", 20) == "hello"
+    print("  ✓ summary truncation")
+
+    # interactionId stable + hex
+    id1 = _hash_interaction_id("whatsapp", "beeper:!r", "2026-04-21T00:00:00+00:00", "inbound", "x")
+    id2 = _hash_interaction_id("whatsapp", "beeper:!r", "2026-04-21T00:00:00+00:00", "inbound", "x")
+    assert id1 == id2 and len(id1) == 16
+    assert all(c in "0123456789abcdef" for c in id1)
+    print("  ✓ interactionId determinism")
+
+    # URL construction with and without params
+    client = BeeperClient()
+    u1 = client._build_url("/v1/chats", None)
+    assert u1 == "http://localhost:23373/v1/chats"
+    u2 = client._build_url("/v1/chats", {"limit": 50, "cursor": "abc", "_skip": None})
+    assert "limit=50" in u2 and "cursor=abc" in u2 and "_skip" not in u2
+    print("  ✓ URL construction")
+
+    # Items extraction absorbs list vs dict-wrapped
+    assert BeeperClient._extract_items([{"id": 1}], key="chats") == [{"id": 1}]
+    assert BeeperClient._extract_items({"chats": [{"id": 2}]}, key="chats") == [{"id": 2}]
+    assert BeeperClient._extract_items({"items": [{"id": 3}]}, key="chats") == [{"id": 3}]
+    assert BeeperClient._extract_items({}, key="chats") == []
+    print("  ✓ response shape absorption")
+
+    # Message normalization
+    client = BeeperClient()
+    chat = {
+        "id": "!room1:beeper.local",
+        "accountID": "acct-wa",
+        "networkID": "whatsapp",
+        "participants": [
+            {"handle": "+421903000001", "fullName": "Test User", "isSelf": False},
+            {"handle": "+421905999999", "isSelf": True},
+        ],
+    }
+    msg_inbound = {
+        "id": "msg-1",
+        "timestamp": "2026-04-20T15:00:00Z",
+        "text": "Hey, can we jump on a demo next week?",
+        "sender": {"handle": "+421903000001", "fullName": "Test User"},
+        "isSender": False,
+    }
+    rec = client._message_to_record(
+        message=msg_inbound, chat=chat, channel="whatsapp",
+        network_id="whatsapp", is_group=False,
+    )
+    assert rec is not None
+    assert rec["channel"] == "whatsapp"
+    assert rec["direction"] == "inbound"
+    assert rec["threadId"] == "beeper:!room1:beeper.local"
+    assert "+421903000001" in rec["matchCandidates"]["phones"]
+    assert any(h.startswith("beeper:whatsapp:") for h in rec["matchCandidates"]["handles"])
+    assert rec["metadata"]["beeperNetwork"] == "whatsapp"
+    assert rec["summary"].startswith("Hey, can we jump")
+    print("  ✓ inbound message normalization")
+
+    # Outbound → direction flipped, participants empty (we drop self-handles)
+    msg_outbound = {
+        "id": "msg-2",
+        "timestamp": "2026-04-20T16:00:00Z",
+        "text": "Sure — Tuesday at 10?",
+        "isSender": True,
+    }
+    rec_out = client._message_to_record(
+        message=msg_outbound, chat=chat, channel="whatsapp",
+        network_id="whatsapp", is_group=False,
+    )
+    assert rec_out["direction"] == "outbound"
+    # Self-sender should not appear in participants/matchCandidates
+    assert not rec_out["participants"] or all(not p.get("self") for p in rec_out["participants"])
+    print("  ✓ outbound direction + self filtering")
+
+    # Missing timestamp → None (not a crash)
+    msg_bad = {"id": "x", "text": "no ts"}
+    assert client._message_to_record(
+        message=msg_bad, chat=chat, channel="whatsapp",
+        network_id="whatsapp", is_group=False,
+    ) is None
+    print("  ✓ missing-timestamp returns None (not raise)")
+
+    # Empty body → placeholder
+    msg_empty = {
+        "id": "e",
+        "timestamp": "2026-04-20T16:00:00Z",
+        "text": "",
+        "attachments": [{"type": "image"}],
+        "isSender": True,
+    }
+    rec_empty = client._message_to_record(
+        message=msg_empty, chat=chat, channel="whatsapp",
+        network_id="whatsapp", is_group=False,
+    )
+    assert rec_empty["summary"] == "[attachment]"
+    print("  ✓ empty-body attachment placeholder")
+
+    # Handle classification
+    assert BeeperClient._classify_handle("user@example.com") == "email"
+    assert BeeperClient._classify_handle("+421903000001") == "phone"
+    assert BeeperClient._classify_handle("@linkedin/foo") == "handle"
+    print("  ✓ handle kind classification")
+
+    print("All offline self-tests passed.")
+
+
+if __name__ == "__main__":
+    import logging as _lg
+    _lg.basicConfig(level=_lg.INFO, format="%(levelname)s %(message)s")
+    _run_self_test()

--- a/harvester/pipeline.py
+++ b/harvester/pipeline.py
@@ -1,0 +1,815 @@
+"""
+Omnichannel harvester — pipeline orchestrator.
+
+Pulls InteractionRecords from channel readers (iMessage chat.db + Beeper
+Desktop API today; Gmail added in a later sprint), matches each record
+to a Google People resourceName, writes monthly-partitioned JSONL to
+`data/interactions/YYYY-MM.jsonl` locally, then uploads to GCS.
+
+Append-only semantics: re-runs dedupe by `interactionId` against the
+existing partition, so overlapping windows are safe.
+
+Entry points:
+- `run_harvest(mode="incremental")` — default cadence, since=cursor, until=now
+- `run_harvest(mode="reconcile", since_timedelta=timedelta(hours=24))` — re-pull
+  the last N hours to catch late-delivery / reactions that an earlier
+  incremental run missed
+- `run_harvest(mode="backfill", backfill_sources=("beeper",))` — full history
+  for a specific reader; used once per install to seed initial data
+
+State files (all under `data/interactions/`):
+- `cursor.json`             — last successful `until` per reader
+- `interaction_match_cache.json` — handle → resourceName from ContactMatcher
+- `interaction_unknowns.jsonl`   — records with no match; append-only review queue
+- `YYYY-MM.jsonl`           — monthly partition, newest first within file
+- `contact_kpis.json`       — ContactKPI rollup (written by score_interactions())
+
+Emergency stop: honours `data/pipeline_paused.json` per the pattern used by
+`entrypoint.py:_check_pause_flag` — same file, same shape, so the dashboard's
+emergency-stop button stops this harvester too.
+
+Run inline self-test (synthetic fixtures, no Beeper / chat.db needed):
+    python -m harvester.pipeline
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Iterable, Iterator, Literal, Optional, Protocol
+
+from config import DATA_DIR
+from utils import upload_file_to_gcs
+from harvester.contact_matcher import ContactMatcher, MatchCache, log_phone_parse_summary
+
+logger = logging.getLogger("contacts-refiner.harvester.pipeline")
+
+
+# ── constants ─────────────────────────────────────────────────────────────
+
+INTERACTIONS_DIR = DATA_DIR / "interactions"
+CURSOR_FILE = INTERACTIONS_DIR / "cursor.json"
+MATCH_CACHE_FILE = INTERACTIONS_DIR / "interaction_match_cache.json"
+UNKNOWNS_FILE = INTERACTIONS_DIR / "interaction_unknowns.jsonl"
+CURSOR_SCHEMA_VERSION = 1
+INCREMENTAL_OVERLAP_MINUTES = 5  # re-scan last N minutes to catch race-window edits
+RECONCILE_DEFAULT_HOURS = 24
+BACKFILL_EARLIEST = datetime(2015, 1, 1, tzinfo=timezone.utc)
+
+Mode = Literal["incremental", "reconcile", "backfill"]
+
+
+# ── reader protocol ───────────────────────────────────────────────────────
+
+class ChannelReader(Protocol):
+    """Matches the contract in docs/schemas/interaction.md §Channel reader."""
+
+    def available(self) -> bool: ...
+    def harvest(
+        self, since: Optional[datetime], until: Optional[datetime],
+    ) -> Iterator[dict]: ...
+
+
+# ── cursor state ──────────────────────────────────────────────────────────
+
+@dataclass
+class CursorState:
+    """Persistent `reader_name → last_until_ts` map.
+
+    A successful harvest updates the cursor for each reader to its new
+    `until`. Failures leave the previous cursor in place — so the next
+    run replays from there.
+    """
+    cursors: dict[str, str] = field(default_factory=dict)
+    schema_version: int = CURSOR_SCHEMA_VERSION
+
+    @classmethod
+    def load(cls, path: Optional[Path] = None) -> "CursorState":
+        # Resolve at call time — tests rebind the module-level CURSOR_FILE.
+        if path is None:
+            path = CURSOR_FILE
+        if not path.exists():
+            return cls()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("CursorState load failed at %s: %s", path, e)
+            return cls()
+        if data.get("schema_version") != CURSOR_SCHEMA_VERSION:
+            logger.warning(
+                "CursorState schema mismatch at %s (file=%s, code=%s) — resetting",
+                path, data.get("schema_version"), CURSOR_SCHEMA_VERSION,
+            )
+            return cls()
+        return cls(cursors=dict(data.get("cursors", {})))
+
+    def save(self, path: Optional[Path] = None) -> None:
+        if path is None:
+            path = CURSOR_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": self.schema_version,
+            "updated": datetime.now(timezone.utc).isoformat(),
+            "cursors": self.cursors,
+        }
+        path.write_text(json.dumps(payload, indent=2))
+
+    def get(self, reader_name: str) -> Optional[datetime]:
+        raw = self.cursors.get(reader_name)
+        if not raw:
+            return None
+        try:
+            s = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+            dt = datetime.fromisoformat(s)
+            return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
+
+    def set(self, reader_name: str, until: datetime) -> None:
+        if until.tzinfo is None:
+            until = until.replace(tzinfo=timezone.utc)
+        self.cursors[reader_name] = until.astimezone(timezone.utc).isoformat()
+
+
+# ── pause flag ────────────────────────────────────────────────────────────
+
+def is_harvester_paused() -> bool:
+    """Same convention as entrypoint.py:_check_pause_flag.
+
+    Fail-safe: if the pause file exists but is unreadable, assume PAUSED.
+    Returns False only when the file is absent or explicitly `{"paused":false}`.
+    """
+    pause_file = DATA_DIR / "pipeline_paused.json"
+    if not pause_file.exists():
+        return False
+    try:
+        data = json.loads(pause_file.read_text(encoding="utf-8"))
+        return bool(data.get("paused"))
+    except (json.JSONDecodeError, OSError) as e:
+        logger.error(
+            "Harvester: pipeline_paused.json unreadable (fail-safe PAUSED): %s", e,
+        )
+        return True
+
+
+# ── partition writer ──────────────────────────────────────────────────────
+
+def _partition_path(ts: datetime, base: Optional[Path] = None) -> Path:
+    if base is None:
+        base = INTERACTIONS_DIR
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    utc_ts = ts.astimezone(timezone.utc)
+    return base / f"{utc_ts.strftime('%Y-%m')}.jsonl"
+
+
+def _existing_ids(partition: Path) -> set[str]:
+    """Load interactionIds already present in `partition` (for dedup).
+
+    Reads line-by-line so a malformed trailing line doesn't blow up the
+    whole file. The worst case (malformed line) is: we re-append a
+    record with a new id, not a silent drop.
+    """
+    if not partition.exists():
+        return set()
+    ids: set[str] = set()
+    with partition.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            iid = obj.get("interactionId")
+            if iid:
+                ids.add(iid)
+    return ids
+
+
+def _append_records(
+    records_by_partition: dict[Path, list[dict]],
+) -> dict[Path, int]:
+    """Append each list of records to its monthly partition.
+
+    Returns a `{partition: records_written}` map for logging.
+    """
+    written: dict[Path, int] = {}
+    for partition, records in records_by_partition.items():
+        if not records:
+            continue
+        partition.parent.mkdir(parents=True, exist_ok=True)
+        with partition.open("a", encoding="utf-8") as f:
+            for rec in records:
+                f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+        written[partition] = len(records)
+    return written
+
+
+# ── unknowns queue ────────────────────────────────────────────────────────
+
+def _append_unknown(record: dict, path: Optional[Path] = None) -> None:
+    """Write one no-match record to the review queue."""
+    if path is None:
+        path = UNKNOWNS_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+# ── contact snapshot loader ───────────────────────────────────────────────
+
+def _load_latest_contacts() -> list[dict]:
+    """Contacts snapshot for the matcher — use the latest backup if any.
+
+    Falls back to the People API if no local backup exists. Matcher
+    performance is fine on both.
+    """
+    from backup import get_latest_backup, load_backup
+    backup_path = get_latest_backup()
+    if backup_path:
+        data = load_backup(backup_path)
+        logger.info("Harvester: contacts from backup %s (n=%d)",
+                    backup_path.name, len(data["contacts"]))
+        return data["contacts"]
+    # No backup — fetch live
+    logger.warning("Harvester: no local backup, fetching contacts live")
+    from auth import authenticate
+    from api_client import PeopleAPIClient
+    client = PeopleAPIClient(authenticate())
+    contacts = client.get_all_contacts()
+    logger.info("Harvester: contacts live (n=%d)", len(contacts))
+    return contacts
+
+
+def _load_linkedin_signals() -> dict[str, dict]:
+    """Feed LinkedIn signals to the matcher so linkedin-handle rows resolve."""
+    try:
+        from followup_scorer import load_linkedin_signals
+        return load_linkedin_signals()
+    except Exception as e:
+        logger.info("Harvester: no LinkedIn signals loaded: %s", e)
+        return {}
+
+
+# ── main run function ─────────────────────────────────────────────────────
+
+@dataclass
+class HarvestSummary:
+    mode: Mode
+    since: Optional[str]
+    until: str
+    readers_ran: list[str] = field(default_factory=list)
+    readers_skipped: list[str] = field(default_factory=list)
+    records_seen: int = 0
+    records_new: int = 0
+    records_matched: int = 0
+    records_unmatched: int = 0
+    records_by_channel: dict[str, int] = field(default_factory=dict)
+    partitions_written: dict[str, int] = field(default_factory=dict)
+    paused: bool = False
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "mode": self.mode,
+            "since": self.since,
+            "until": self.until,
+            "readers_ran": self.readers_ran,
+            "readers_skipped": self.readers_skipped,
+            "records_seen": self.records_seen,
+            "records_new": self.records_new,
+            "records_matched": self.records_matched,
+            "records_unmatched": self.records_unmatched,
+            "records_by_channel": self.records_by_channel,
+            "partitions_written": self.partitions_written,
+            "paused": self.paused,
+            "errors": self.errors,
+        }
+
+
+def run_harvest(
+    *,
+    mode: Mode = "incremental",
+    since_timedelta: Optional[timedelta] = None,
+    backfill_sources: Optional[Iterable[str]] = None,
+    readers: Optional[dict[str, ChannelReader]] = None,
+    contacts: Optional[list[dict]] = None,
+    linkedin_signals: Optional[dict[str, dict]] = None,
+    upload_to_gcs: bool = True,
+    now_fn: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+) -> HarvestSummary:
+    """Drive one harvest across all available readers.
+
+    Pure business logic — no argparse. Callable from `main.py` or tests.
+
+    Modes:
+      - `incremental`: since = last cursor (or 24h ago if first run),
+        until = now. Overlaps the last INCREMENTAL_OVERLAP_MINUTES to
+        catch edits/reactions.
+      - `reconcile`: since = now - since_timedelta (default 24h),
+        until = now. Ignores cursors. Used by the daily launchd job.
+      - `backfill`: since = BACKFILL_EARLIEST, until = now. Only runs
+        readers in `backfill_sources`.
+    """
+    summary = HarvestSummary(mode=mode, since=None, until="")
+
+    if is_harvester_paused():
+        logger.warning("Harvester: paused via pipeline_paused.json — exiting cleanly")
+        summary.paused = True
+        summary.until = now_fn().isoformat()
+        return summary
+
+    # Resolve readers lazily — tests inject, prod builds live.
+    if readers is None:
+        readers = _build_default_readers()
+
+    now = now_fn()
+    cursors = CursorState.load()
+
+    # Resolve contacts + LinkedIn signals once, share across readers.
+    contacts = contacts if contacts is not None else _load_latest_contacts()
+    linkedin_signals = (
+        linkedin_signals
+        if linkedin_signals is not None
+        else _load_linkedin_signals()
+    )
+
+    match_cache = MatchCache.load(MATCH_CACHE_FILE)
+    matcher = ContactMatcher(
+        contacts, linkedin_signals=linkedin_signals, match_cache=match_cache,
+    )
+
+    # Accumulate per-partition so we do one file open per month per run.
+    records_by_partition: dict[Path, list[dict]] = {}
+    existing_ids_cache: dict[Path, set[str]] = {}
+
+    for reader_name, reader in readers.items():
+        if mode == "backfill" and backfill_sources and reader_name not in backfill_sources:
+            continue
+
+        if not reader.available():
+            logger.info("Harvester: reader '%s' unavailable — skipping", reader_name)
+            summary.readers_skipped.append(reader_name)
+            continue
+
+        since, until = _resolve_window(
+            mode=mode, reader_name=reader_name, cursors=cursors,
+            since_timedelta=since_timedelta, now=now,
+        )
+        if summary.since is None:
+            summary.since = since.isoformat() if since else None
+        summary.until = until.isoformat()
+
+        logger.info(
+            "Harvester: running reader=%s since=%s until=%s mode=%s",
+            reader_name,
+            since.isoformat() if since else "null",
+            until.isoformat(),
+            mode,
+        )
+
+        try:
+            new_records = _run_single_reader(
+                reader=reader,
+                reader_name=reader_name,
+                since=since,
+                until=until,
+                matcher=matcher,
+                records_by_partition=records_by_partition,
+                existing_ids_cache=existing_ids_cache,
+                summary=summary,
+            )
+        except Exception as e:
+            # Never let one reader's crash halt the whole harvest — log
+            # and move on. The next run's cursor is unchanged for this
+            # reader, so we'll retry the same window.
+            logger.exception("Harvester: reader '%s' raised: %s", reader_name, e)
+            summary.errors.append(f"{reader_name}: {e}")
+            continue
+
+        # Only advance the cursor on success.
+        cursors.set(reader_name, until)
+        summary.readers_ran.append(reader_name)
+        logger.info(
+            "Harvester: reader '%s' produced %d new records", reader_name, new_records,
+        )
+
+    # Flush accumulated records to disk + GCS.
+    written = _append_records(records_by_partition)
+    for partition, count in written.items():
+        summary.partitions_written[partition.name] = count
+        if upload_to_gcs:
+            blob = f"data/interactions/{partition.name}"
+            try:
+                upload_file_to_gcs(partition, blob, "harvester")
+            except Exception as e:
+                logger.warning("Harvester: GCS upload failed for %s: %s", partition.name, e)
+                summary.errors.append(f"gcs_upload[{partition.name}]: {e}")
+
+    matcher.save_cache(MATCH_CACHE_FILE)
+    cursors.save()
+    log_phone_parse_summary()
+    logger.info("Harvester summary: %s", summary.to_dict())
+    return summary
+
+
+def _resolve_window(
+    *,
+    mode: Mode,
+    reader_name: str,
+    cursors: CursorState,
+    since_timedelta: Optional[timedelta],
+    now: datetime,
+) -> tuple[Optional[datetime], datetime]:
+    """Compute [since, until) for one reader under the given mode.
+
+    Returns `(since, until)`. `since=None` in backfill mode means the
+    reader should go as far back as it can.
+    """
+    if mode == "backfill":
+        return BACKFILL_EARLIEST, now
+
+    if mode == "reconcile":
+        delta = since_timedelta or timedelta(hours=RECONCILE_DEFAULT_HOURS)
+        return now - delta, now
+
+    # incremental
+    last_cursor = cursors.get(reader_name)
+    if last_cursor is None:
+        # First run — look back 24h by default. Too short and we miss
+        # history; too long and the first run takes forever.
+        return now - timedelta(hours=24), now
+
+    # Overlap N minutes to catch edits/reactions/read-receipts that
+    # arrived between our last `until` and the message's actual final
+    # state on the other end.
+    overlap = timedelta(minutes=INCREMENTAL_OVERLAP_MINUTES)
+    return last_cursor - overlap, now
+
+
+def _run_single_reader(
+    *,
+    reader: ChannelReader,
+    reader_name: str,
+    since: Optional[datetime],
+    until: datetime,
+    matcher: ContactMatcher,
+    records_by_partition: dict[Path, list[dict]],
+    existing_ids_cache: dict[Path, set[str]],
+    summary: HarvestSummary,
+) -> int:
+    """Harvest one reader, match+dedup each record, add to pending writes.
+
+    Returns the number of new records (post-dedup) queued for this reader.
+    """
+    new_count = 0
+    seen_in_run: set[str] = set()  # intra-run dedup (two readers seeing same msg)
+
+    for record in reader.harvest(since=since, until=until):
+        summary.records_seen += 1
+        ch = record.get("channel") or reader_name
+        summary.records_by_channel[ch] = summary.records_by_channel.get(ch, 0) + 1
+
+        iid = record.get("interactionId")
+        if not iid:
+            continue
+        if iid in seen_in_run:
+            continue
+        seen_in_run.add(iid)
+
+        ts_raw = record.get("timestamp")
+        if not ts_raw:
+            continue
+        ts = _parse_ts(ts_raw)
+        if ts is None:
+            continue
+
+        partition = _partition_path(ts)
+        if partition not in existing_ids_cache:
+            existing_ids_cache[partition] = _existing_ids(partition)
+        if iid in existing_ids_cache[partition]:
+            # Already persisted from a prior run — dedup and move on.
+            continue
+
+        # Contact match — mutate the record in place so the stored row
+        # carries contactId.
+        resolved = matcher.match(record)
+        if resolved:
+            record["contactId"] = resolved
+            summary.records_matched += 1
+        else:
+            record["contactId"] = None
+            summary.records_unmatched += 1
+            _append_unknown(record)
+
+        records_by_partition.setdefault(partition, []).append(record)
+        existing_ids_cache[partition].add(iid)
+        new_count += 1
+        summary.records_new += 1
+
+    return new_count
+
+
+def _parse_ts(value: str) -> Optional[datetime]:
+    try:
+        s = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        dt = datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _build_default_readers() -> dict[str, ChannelReader]:
+    """Production readers — iMessage (chat.db) + Beeper (Desktop API).
+
+    Gmail reader lands in a later sprint; the map lets us add it without
+    touching run_harvest.
+    """
+    from harvester.beeper_client import BeeperClient
+    from harvester.imessage_reader import IMessageReader
+    return {
+        "imessage": IMessageReader(),
+        "beeper": BeeperClient(),
+    }
+
+
+# ── scoring bridge ────────────────────────────────────────────────────────
+
+def score_interactions_cli(
+    *,
+    partitions_glob: str = "*.jsonl",
+    out_path: Optional[Path] = None,
+    upload_to_gcs: bool = True,
+) -> dict:
+    """Load all interaction partitions, derive ContactKPIs, persist JSON.
+
+    Used by `main.py score-interactions`. Loads every `YYYY-MM.jsonl` in
+    `data/interactions/`, groups by contactId, runs
+    `scoring_signals.derive_all_kpis`, and writes
+    `data/interactions/contact_kpis.json`.
+
+    Unmatched records (contactId=null) are ignored — they have no
+    resourceName to roll up under.
+    """
+    from harvester.scoring_signals import (
+        derive_all_kpis, save_kpis_to_json,
+    )
+    from config import FOLLOWUP_BEEPER_KPI_FILE
+
+    if out_path is None:
+        out_path = FOLLOWUP_BEEPER_KPI_FILE
+
+    records_by_contact: dict[str, list[dict]] = {}
+    total = 0
+    unmatched = 0
+    for partition in sorted(INTERACTIONS_DIR.glob(partitions_glob)):
+        # Skip contact_kpis.json / cursor.json / match_cache.json — they
+        # match *.jsonl only, but be defensive.
+        if not partition.name.endswith(".jsonl"):
+            continue
+        if partition.name in ("interaction_unknowns.jsonl",):
+            continue
+        with partition.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                total += 1
+                rn = rec.get("contactId")
+                if not rn:
+                    unmatched += 1
+                    continue
+                records_by_contact.setdefault(rn, []).append(rec)
+
+    logger.info(
+        "score-interactions: loaded %d records across %d contacts (%d unmatched)",
+        total, len(records_by_contact), unmatched,
+    )
+
+    kpis = derive_all_kpis(records_by_contact)
+    save_kpis_to_json(kpis, out_path)
+
+    if upload_to_gcs:
+        try:
+            upload_file_to_gcs(out_path, "data/interactions/contact_kpis.json", "harvester")
+        except Exception as e:
+            logger.warning("score-interactions: GCS upload failed: %s", e)
+
+    return {
+        "total_records": total,
+        "unmatched_records": unmatched,
+        "contacts_scored": len(kpis),
+        "out_path": str(out_path),
+    }
+
+
+# ── CLI self-test ─────────────────────────────────────────────────────────
+
+class _FakeReader:
+    """Test reader that yields preset records deterministically."""
+
+    def __init__(self, records: list[dict], available: bool = True):
+        self._records = records
+        self._available = available
+
+    def available(self) -> bool:
+        return self._available
+
+    def harvest(
+        self, since: Optional[datetime], until: Optional[datetime],
+    ) -> Iterator[dict]:
+        for r in self._records:
+            ts = _parse_ts(r.get("timestamp") or "")
+            if since and ts and ts < since:
+                continue
+            if until and ts and ts >= until:
+                continue
+            yield r
+
+
+def _run_self_test() -> None:
+    import tempfile
+    print("pipeline self-test (offline, synthetic fixtures)…")
+
+    # Redirect DATA_DIR for this test — can't easily monkey-patch config,
+    # so use the global INTERACTIONS_DIR override via temp dir.
+    with tempfile.TemporaryDirectory() as tmp:
+        global INTERACTIONS_DIR, CURSOR_FILE, MATCH_CACHE_FILE, UNKNOWNS_FILE
+        saved = (INTERACTIONS_DIR, CURSOR_FILE, MATCH_CACHE_FILE, UNKNOWNS_FILE)
+        INTERACTIONS_DIR = Path(tmp) / "interactions"
+        CURSOR_FILE = INTERACTIONS_DIR / "cursor.json"
+        MATCH_CACHE_FILE = INTERACTIONS_DIR / "interaction_match_cache.json"
+        UNKNOWNS_FILE = INTERACTIONS_DIR / "interaction_unknowns.jsonl"
+        INTERACTIONS_DIR.mkdir(parents=True)
+
+        try:
+            _assert_basic_run()
+            _assert_dedup()
+            _assert_pause()
+            _assert_cursor_advance()
+            _assert_reader_crash_isolated()
+        finally:
+            INTERACTIONS_DIR, CURSOR_FILE, MATCH_CACHE_FILE, UNKNOWNS_FILE = saved
+
+    print("All pipeline self-tests passed.")
+
+
+def _assert_basic_run() -> None:
+    contacts = [
+        {"resourceName": "people/c1",
+         "names": [{"displayName": "Alice Test"}],
+         "emailAddresses": [{"value": "alice@example.com"}],
+         "phoneNumbers": []},
+        {"resourceName": "people/c2",
+         "names": [{"displayName": "Bob Test"}],
+         "emailAddresses": [],
+         "phoneNumbers": [{"value": "+421903111111"}]},
+    ]
+    ts = datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc)
+    fake_records = [
+        {
+            "interactionId": "aa11bb22cc33dd44",
+            "contactId": None,
+            "matchCandidates": {"emails": ["alice@example.com"], "phones": [], "handles": []},
+            "channel": "gmail", "direction": "inbound",
+            "threadId": "gmail:t1", "timestamp": ts.isoformat(),
+            "subject": "demo", "summary": "hi",
+            "participants": [], "metadata": {"source": "gmail"},
+        },
+        {
+            "interactionId": "ee55ff66aa77bb88",
+            "contactId": None,
+            "matchCandidates": {"emails": [], "phones": ["+421903111111"], "handles": []},
+            "channel": "whatsapp", "direction": "outbound",
+            "threadId": "beeper:!room1", "timestamp": ts.isoformat(),
+            "subject": None, "summary": "ping",
+            "participants": [], "metadata": {"source": "beeper"},
+        },
+    ]
+    readers = {"fake": _FakeReader(fake_records)}
+    summary = run_harvest(
+        mode="incremental", readers=readers,
+        contacts=contacts, linkedin_signals={},
+        upload_to_gcs=False,
+    )
+    assert summary.records_new == 2, summary
+    assert summary.records_matched == 2, summary
+    assert summary.readers_ran == ["fake"], summary
+    partition = _partition_path(ts)
+    assert partition.exists(), partition
+    lines = partition.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2, lines
+    first = json.loads(lines[0])
+    assert first["contactId"] in ("people/c1", "people/c2")
+    print("  ✓ basic run writes matched records to monthly partition")
+
+
+def _assert_dedup() -> None:
+    contacts = [{"resourceName": "people/c1",
+                 "names": [{"displayName": "Alice Test"}],
+                 "emailAddresses": [{"value": "alice@example.com"}],
+                 "phoneNumbers": []}]
+    # Use a timestamp that lands inside a 1h reconcile window anchored at `now`.
+    ts = datetime.now(timezone.utc) - timedelta(minutes=5)
+    rec = {
+        "interactionId": "dedup1234567890a",
+        "contactId": None,
+        "matchCandidates": {"emails": ["alice@example.com"], "phones": [], "handles": []},
+        "channel": "gmail", "direction": "inbound",
+        "threadId": "gmail:t2", "timestamp": ts.isoformat(),
+        "subject": "x", "summary": "y",
+        "participants": [], "metadata": {"source": "gmail"},
+    }
+    readers = {"fake": _FakeReader([rec, rec])}  # duplicate intra-run
+    summary = run_harvest(
+        mode="reconcile", since_timedelta=timedelta(hours=1), readers=readers,
+        contacts=contacts, linkedin_signals={}, upload_to_gcs=False,
+    )
+    assert summary.records_new == 1, f"intra-run dedup: {summary}"
+
+    # Now re-run — should dedup against existing partition
+    readers2 = {"fake": _FakeReader([rec])}
+    summary2 = run_harvest(
+        mode="reconcile", since_timedelta=timedelta(hours=1), readers=readers2,
+        contacts=contacts, linkedin_signals={}, upload_to_gcs=False,
+    )
+    assert summary2.records_new == 0, f"cross-run dedup: {summary2}"
+    print("  ✓ dedup (intra-run + cross-run)")
+
+
+def _assert_pause() -> None:
+    pause_path = DATA_DIR / "pipeline_paused.json"
+    pause_path.write_text(json.dumps({"paused": True}))
+    try:
+        summary = run_harvest(
+            mode="incremental", readers={}, contacts=[],
+            linkedin_signals={}, upload_to_gcs=False,
+        )
+        assert summary.paused is True, summary
+        print("  ✓ pause flag honoured")
+    finally:
+        pause_path.unlink(missing_ok=True)
+
+
+def _assert_cursor_advance() -> None:
+    contacts = [{"resourceName": "people/c1",
+                 "names": [{"displayName": "Alice"}],
+                 "emailAddresses": [{"value": "alice@example.com"}],
+                 "phoneNumbers": []}]
+    ts = datetime(2026, 4, 21, 10, 0, tzinfo=timezone.utc)
+    readers = {"fake": _FakeReader([{
+        "interactionId": "cursor1234567890x",
+        "contactId": None,
+        "matchCandidates": {"emails": ["alice@example.com"], "phones": [], "handles": []},
+        "channel": "gmail", "direction": "inbound",
+        "threadId": "gmail:c1", "timestamp": ts.isoformat(),
+        "subject": None, "summary": "",
+        "participants": [], "metadata": {"source": "gmail"},
+    }])}
+    fixed_now = datetime(2026, 4, 21, 11, 0, tzinfo=timezone.utc)
+    run_harvest(
+        mode="incremental", readers=readers,
+        contacts=contacts, linkedin_signals={}, upload_to_gcs=False,
+        now_fn=lambda: fixed_now,
+    )
+    state = CursorState.load(CURSOR_FILE)
+    assert state.get("fake") == fixed_now, state.cursors
+    print("  ✓ cursor advanced to `until`")
+
+
+def _assert_reader_crash_isolated() -> None:
+    class _CrashReader:
+        def available(self):
+            return True
+        def harvest(self, since, until):
+            yield {"interactionId": "x", "timestamp": "2026-04-21T12:00:00+00:00",
+                   "channel": "x", "direction": "inbound", "threadId": "x",
+                   "matchCandidates": {"emails": [], "phones": [], "handles": []},
+                   "participants": [], "metadata": {}}
+            raise RuntimeError("simulated reader crash")
+
+    contacts = []
+    summary = run_harvest(
+        mode="incremental", readers={"crash": _CrashReader()},
+        contacts=contacts, linkedin_signals={}, upload_to_gcs=False,
+    )
+    assert "crash" in [e.split(":")[0] for e in summary.errors], summary.errors
+    assert "crash" not in summary.readers_ran
+    print("  ✓ reader crash isolated (logged + recorded, pipeline continues)")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    _run_self_test()

--- a/main.py
+++ b/main.py
@@ -3,19 +3,23 @@
 Google Contacts Cleanup Tool — Main CLI Entry Point.
 
 Usage:
-    python main.py auth           # Setup OAuth and test connection
-    python main.py backup         # Create a full backup
-    python main.py analyze        # Analyze contacts and generate workplan
-    python main.py fix            # Apply fixes interactively (batch approval)
-    python main.py verify         # Verify changes against backup
-    python main.py rollback       # Rollback changes from changelog
-    python main.py resume         # Resume from last checkpoint
-    python main.py info           # Show session/backup/workplan info
-    python main.py auth-activity  # Authenticate for Gmail+Calendar scanning
-    python main.py tag-activity   # Scan interactions and assign year labels
-    python main.py ltns           # Identify LTNS contacts and generate reconnect prompts
-    python main.py linkedin-scan  # Scan LinkedIn profiles for social signals
-    python main.py followup       # Score FollowUp candidates (LinkedIn + interaction signals)
+    python main.py auth                 # Setup OAuth and test connection
+    python main.py backup               # Create a full backup
+    python main.py analyze              # Analyze contacts and generate workplan
+    python main.py fix                  # Apply fixes interactively (batch approval)
+    python main.py verify               # Verify changes against backup
+    python main.py rollback             # Rollback changes from changelog
+    python main.py resume               # Resume from last checkpoint
+    python main.py info                 # Show session/backup/workplan info
+    python main.py auth-activity        # Authenticate for Gmail+Calendar scanning
+    python main.py tag-activity         # Scan interactions and assign year labels
+    python main.py ltns                 # Identify LTNS contacts and generate reconnect prompts
+    python main.py linkedin-scan        # Scan LinkedIn profiles for social signals
+    python main.py followup             # Score FollowUp candidates (LinkedIn + interaction signals)
+    python main.py harvest-messages     # Omnichannel harvester (Beeper + iMessage → GCS)
+                   --incremental | --reconcile [--since=24h] | --backfill --source=beeper
+    python main.py backfill-beeper      # Alias for harvest-messages --backfill --source=beeper
+    python main.py score-interactions   # Derive ContactKPIs from harvested interactions
 """
 import os
 import sys
@@ -1083,9 +1087,10 @@ def cmd_followup(skip_scan=False, dry_run=False, no_prompts=False):
     from auth import authenticate, authenticate_for_activity
     from interaction_scanner import InteractionScanner
     from followup_scorer import (
+        build_followup_scores_json,
+        load_contact_kpis,
         load_linkedin_signals,
         score_contacts,
-        build_followup_scores_json,
         upload_followup_scores_to_gcs,
     )
 
@@ -1144,6 +1149,13 @@ def cmd_followup(skip_scan=False, dry_run=False, no_prompts=False):
         print(f"   {types}")
     print()
 
+    # Step 3b: Load ContactKPI rollups from harvester (#150). Graceful fallback
+    # to {} when file is missing / schema-mismatched — scoring stays pre-Beeper.
+    contact_kpis = load_contact_kpis()
+    if contact_kpis:
+        print(f"📨 Beeper ContactKPIs loaded: {len(contact_kpis)}")
+        print()
+
     # Step 4: Score candidates
     print("📊 Scoring FollowUp candidates...")
     scored = score_contacts(
@@ -1151,6 +1163,7 @@ def cmd_followup(skip_scan=False, dry_run=False, no_prompts=False):
         interactions=scanner._interactions,
         contact_emails=scanner._contact_emails,
         linkedin_signals=linkedin_signals,
+        contact_kpis=contact_kpis,
         top_n=FOLLOWUP_TOP_N,
     )
 
@@ -1359,6 +1372,129 @@ def cmd_linkedin_scan(skip_scan=False, dry_run=False, limit=100, groups=None):
     return targets
 
 
+def cmd_harvest_messages(
+    mode: str = "incremental",
+    since: str | None = None,
+    source: str | None = None,
+) -> int:
+    """Run the omnichannel harvester.
+
+    mode:
+      - "incremental" — since=last cursor (or 24h ago if first run), until=now
+      - "reconcile"   — re-pull the last `since` window (default 24h)
+      - "backfill"    — full-history, only for readers listed in `source`
+
+    Returns the number of new records written (0 when paused or no sources).
+    """
+    from datetime import timedelta
+    from harvester.pipeline import run_harvest
+
+    print("📨 Omnichannel Harvester")
+    print("=" * 50)
+    print()
+
+    since_delta = _parse_since_to_timedelta(since) if since else None
+    backfill_sources = tuple(s.strip() for s in source.split(",")) if source else None
+
+    if mode not in ("incremental", "reconcile", "backfill"):
+        print(f"❌ Unknown harvest mode: {mode}")
+        return 0
+    if mode == "backfill" and not backfill_sources:
+        print("❌ --backfill requires --source=<reader>[,<reader>]")
+        return 0
+
+    summary = run_harvest(
+        mode=mode,
+        since_timedelta=since_delta,
+        backfill_sources=backfill_sources,
+    )
+
+    print()
+    if summary.paused:
+        print("⏸  Harvester paused (pipeline_paused.json set). Exited cleanly.")
+        return 0
+
+    print(f"  Mode:          {summary.mode}")
+    print(f"  Since:         {summary.since or '(none)'}")
+    print(f"  Until:         {summary.until}")
+    print(f"  Readers ran:   {', '.join(summary.readers_ran) or '(none)'}")
+    if summary.readers_skipped:
+        print(f"  Readers off:   {', '.join(summary.readers_skipped)}")
+    print(f"  Records seen:  {summary.records_seen}")
+    print(f"  Records new:   {summary.records_new}")
+    print(f"  Matched:       {summary.records_matched}")
+    print(f"  Unmatched:     {summary.records_unmatched}")
+    if summary.records_by_channel:
+        print(f"  By channel:    {summary.records_by_channel}")
+    if summary.partitions_written:
+        print(f"  Partitions:    {summary.partitions_written}")
+    if summary.errors:
+        print(f"  Errors:        {len(summary.errors)}")
+        for e in summary.errors[:5]:
+            print(f"    - {e}")
+    print()
+    return summary.records_new
+
+
+def _parse_since_to_timedelta(raw: str):
+    """Parse a shorthand duration: `24h`, `7d`, `30m`. Returns a timedelta.
+
+    Raises ValueError on malformed input so the CLI fails loudly rather
+    than silently defaulting to 24h. Callers pass the user's literal.
+    """
+    from datetime import timedelta
+    s = raw.strip().lower()
+    if not s:
+        raise ValueError(f"--since value is empty")
+    unit = s[-1]
+    try:
+        num = float(s[:-1])
+    except ValueError:
+        raise ValueError(f"--since must be a number + unit (e.g. 24h, 7d, 30m): {raw!r}")
+    if unit == "h":
+        return timedelta(hours=num)
+    if unit == "d":
+        return timedelta(days=num)
+    if unit == "m":
+        return timedelta(minutes=num)
+    raise ValueError(f"--since unit must be one of h/d/m: {raw!r}")
+
+
+def cmd_backfill_beeper() -> int:
+    """Full-history Beeper backfill — one-shot at install time.
+
+    Thin wrapper around `harvest-messages --backfill --source=beeper`
+    so the launchd weekly plist can invoke a single subcommand.
+    """
+    return cmd_harvest_messages(mode="backfill", source="beeper")
+
+
+def cmd_score_interactions() -> int:
+    """Derive ContactKPI rollups from data/interactions/*.jsonl.
+
+    Reads every monthly partition, groups by contactId, runs
+    `scoring_signals.derive_all_kpis`, writes
+    `data/interactions/contact_kpis.json`, and uploads to GCS.
+
+    Exit code 0 on success; 1 on error. Returns the count of contacts
+    scored for the caller's convenience.
+    """
+    from harvester.pipeline import score_interactions_cli
+
+    print("📊 Score Interactions — Derive ContactKPIs")
+    print("=" * 50)
+    print()
+
+    result = score_interactions_cli()
+    print(f"  Total records:    {result['total_records']}")
+    print(f"  Unmatched:        {result['unmatched_records']}")
+    print(f"  Contacts scored:  {result['contacts_scored']}")
+    print(f"  Output:           {result['out_path']}")
+    print()
+    print("✅ Done.")
+    return result["contacts_scored"]
+
+
 def cmd_crm_sync(dry_run=False):
     """Sync CRM notes and tags from dashboard to Google Contacts."""
     from crm_sync import run_crm_sync
@@ -1446,6 +1582,7 @@ def main():
             "verify", "rollback", "resume", "info",
             "auth-activity", "tag-activity", "ltns", "followup",
             "linkedin-match", "linkedin-scan", "crm-sync", "refresh-tables",
+            "harvest-messages", "backfill-beeper", "score-interactions",
         ],
         help="Command to execute",
     )
@@ -1458,6 +1595,12 @@ def main():
     parser.add_argument("--limit", type=int, default=100, help="Max profiles to scan (for linkedin-scan)")
     parser.add_argument("--write-notes", action="store_true", help="Write cached scan results to notes (for linkedin-scan)")
     parser.add_argument("--groups", type=str, help="Comma-separated group names to filter targets (for linkedin-scan, e.g. Y2025,Y2026)")
+    # harvest-messages flags — mutually-exclusive modes implemented via three flags.
+    parser.add_argument("--incremental", action="store_true", help="harvest-messages: since=cursor mode (default)")
+    parser.add_argument("--reconcile", action="store_true", help="harvest-messages: re-pull recent window ignoring cursor")
+    parser.add_argument("--backfill", action="store_true", help="harvest-messages: full-history; requires --source")
+    parser.add_argument("--since", type=str, help="harvest-messages --reconcile: lookback window, e.g. 24h / 7d / 30m")
+    parser.add_argument("--source", type=str, help="harvest-messages --backfill: reader name(s), e.g. beeper or beeper,imessage")
 
     args = parser.parse_args()
 
@@ -1520,6 +1663,19 @@ def main():
             )
         elif command == "crm-sync":
             cmd_crm_sync(dry_run=args.dry_run)
+        elif command == "harvest-messages":
+            # Default is --incremental. --reconcile and --backfill override.
+            if args.backfill:
+                mode = "backfill"
+            elif args.reconcile:
+                mode = "reconcile"
+            else:
+                mode = "incremental"
+            cmd_harvest_messages(mode=mode, since=args.since, source=args.source)
+        elif command == "backfill-beeper":
+            cmd_backfill_beeper()
+        elif command == "score-interactions":
+            cmd_score_interactions()
         elif command in simple_commands:
             simple_commands[command]()
         else:

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -2,12 +2,22 @@
 # Install harvester launchd agents on macOS.
 #
 # Copies launchagents/*.plist → ~/Library/LaunchAgents/ with user-specific
-# path rewrites, then loads them via launchctl.
+# path rewrites, loads them via launchctl, and drops a newsyslog.d entry
+# to rotate harvester logs (keeps ~/Library/Logs/contactrefiner bounded).
 #
-# Idempotent: unload any existing agent before reinstalling.
+# SAFETY — dry-run by default.
+#   ./scripts/install-launchd.sh            → prints what it WOULD do, no changes
+#   ./scripts/install-launchd.sh --apply    → actually copies, loads, rotates
+#   ./scripts/install-launchd.sh --uninstall → unload + remove plists (no trash)
 #
-# Status: template. Relies on main.py harvest-messages / backfill-beeper /
-# score-interactions / crm-sync subcommands landing in Sprint 3.33.
+# Idempotent under --apply: unload existing agents before reinstalling.
+#
+# Deferred review items from #151 rolled in here:
+#   - reachability probe: harvester/beeper_oauth.is_beeper_reachable() is called
+#     at every harvester entry point; this script doesn't need an extra hook
+#   - pipeline_paused check: harvester/pipeline.is_harvester_paused() fires on
+#     every run; no script-level work needed
+#   - log rotation via newsyslog.d — handled below
 
 set -euo pipefail
 
@@ -15,6 +25,8 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LAUNCH_DIR="${HOME}/Library/LaunchAgents"
 LOG_DIR="${HOME}/Library/Logs/contactrefiner"
 UV_BIN="$(command -v uv || echo /opt/homebrew/bin/uv)"
+NEWSYSLOG_DIR="/etc/newsyslog.d"
+NEWSYSLOG_FILE="${NEWSYSLOG_DIR}/contactrefiner-harvester.conf"
 
 AGENTS=(
   "com.contactrefiner.harvester.hourly"
@@ -23,15 +35,84 @@ AGENTS=(
   "com.contactrefiner.harvester.monthly"
 )
 
+MODE="dry-run"
+for arg in "$@"; do
+  case "$arg" in
+    --apply)    MODE="apply" ;;
+    --uninstall) MODE="uninstall" ;;
+    --help|-h)
+      echo "Usage: $0 [--apply | --uninstall | --help]" >&2
+      exit 0 ;;
+    *)
+      echo "error: unknown flag: $arg" >&2
+      echo "run with --help for usage" >&2
+      exit 2 ;;
+  esac
+done
+
+log() { echo "[install-launchd] $*"; }
+
+# Pre-flight checks — run even in dry-run so the user sees real blockers upfront.
 if [[ ! -x "${UV_BIN}" ]]; then
-  echo "error: uv not found. Install with: brew install uv" >&2
+  log "error: uv not found. Install with: brew install uv"
   exit 1
 fi
 
 if [[ ! -f "${REPO_ROOT}/main.py" ]]; then
-  echo "error: main.py not found at ${REPO_ROOT}/main.py" >&2
+  log "error: main.py not found at ${REPO_ROOT}/main.py"
   exit 1
 fi
+
+# Verify all plists exist BEFORE claiming we're ready.
+MISSING=()
+for agent in "${AGENTS[@]}"; do
+  if [[ ! -f "${REPO_ROOT}/launchagents/${agent}.plist" ]]; then
+    MISSING+=("${agent}.plist")
+  fi
+done
+if (( ${#MISSING[@]} > 0 )); then
+  log "error: missing plist templates: ${MISSING[*]}"
+  exit 1
+fi
+
+# ── uninstall path ────────────────────────────────────────────────────────
+if [[ "${MODE}" == "uninstall" ]]; then
+  for agent in "${AGENTS[@]}"; do
+    dst="${LAUNCH_DIR}/${agent}.plist"
+    if [[ -f "${dst}" ]]; then
+      launchctl unload "${dst}" 2>/dev/null || true
+      rm -f "${dst}"
+      log "✓ removed ${agent}"
+    else
+      log "  ${agent} not installed — skipping"
+    fi
+  done
+  log "Uninstall complete. newsyslog entry left in place at ${NEWSYSLOG_FILE}"
+  log "  (remove manually if desired — requires sudo)"
+  exit 0
+fi
+
+# ── plan / dry-run output ─────────────────────────────────────────────────
+log "mode: ${MODE}"
+log "repo: ${REPO_ROOT}"
+log "uv:   ${UV_BIN}"
+log "logs: ${LOG_DIR}"
+log ""
+log "would install these agents into ${LAUNCH_DIR}:"
+for agent in "${AGENTS[@]}"; do
+  log "  - ${agent}.plist"
+done
+log ""
+log "would write newsyslog.d rotation config to:"
+log "  ${NEWSYSLOG_FILE}  (requires sudo)"
+log ""
+
+if [[ "${MODE}" == "dry-run" ]]; then
+  log "dry-run only — re-run with --apply to actually install."
+  exit 0
+fi
+
+# ── apply path ────────────────────────────────────────────────────────────
 
 mkdir -p "${LAUNCH_DIR}"
 mkdir -p "${LOG_DIR}"
@@ -48,11 +129,6 @@ for agent in "${AGENTS[@]}"; do
   src="${REPO_ROOT}/launchagents/${agent}.plist"
   dst="${LAUNCH_DIR}/${agent}.plist"
 
-  if [[ ! -f "${src}" ]]; then
-    echo "warn: ${src} missing, skipping" >&2
-    continue
-  fi
-
   # Unload if already loaded (idempotent reinstall)
   launchctl unload "${dst}" 2>/dev/null || true
 
@@ -64,10 +140,35 @@ for agent in "${AGENTS[@]}"; do
       "${src}" > "${dst}"
 
   launchctl load "${dst}"
-  echo "✓ loaded ${agent}"
+  log "✓ loaded ${agent}"
 done
 
-echo ""
-echo "Installed ${#AGENTS[@]} launch agents."
-echo "Logs: ${LOG_DIR}/harvester-*.log"
-echo "Uninstall: ./scripts/uninstall-launchd.sh"
+# ── log rotation (newsyslog.d) ────────────────────────────────────────────
+# Rotate each .log when it hits 5MB, keep 4 rotations gzipped. Uses * in path
+# so both .log (stdout) and .err (stderr) get rotated.
+#
+# Requires sudo because /etc/newsyslog.d is root-owned. We write to a temp
+# file first and use `sudo install` so failure leaves no half-configured state.
+TMP_NS="$(mktemp -t contactrefiner-newsyslog.XXXXXX)"
+cat > "${TMP_NS}" <<EOF
+# Rotate ContactRefiner harvester logs.
+# Installed by scripts/install-launchd.sh — edit there, not here.
+# Format: logfile_name  [owner:group]  mode  count  size  when  flags
+${LOG_DIR}/harvester-*.log   $(whoami):staff  644   4    5120    *     GZ
+${LOG_DIR}/harvester-*.err   $(whoami):staff  644   4    5120    *     GZ
+EOF
+
+if sudo -n true 2>/dev/null; then
+  sudo install -m 0644 "${TMP_NS}" "${NEWSYSLOG_FILE}"
+  log "✓ wrote ${NEWSYSLOG_FILE}"
+else
+  log "ℹ  newsyslog.d config prepared at ${TMP_NS}"
+  log "   run: sudo install -m 0644 ${TMP_NS} ${NEWSYSLOG_FILE}"
+  log "   (sudo not available non-interactively; skipped)"
+fi
+rm -f "${TMP_NS}"
+
+log ""
+log "Installed ${#AGENTS[@]} launch agents."
+log "Logs: ${LOG_DIR}/harvester-*.log (rotated via newsyslog.d)"
+log "Uninstall: ./scripts/install-launchd.sh --uninstall"


### PR DESCRIPTION
## Summary
- Harvester kernel lands: `beeper_client.py` (HTTP transport over 3.32 S1 OAuth helper) + `pipeline.py` (orchestration with incremental / reconcile / backfill modes, monthly JSONL partitions, dedup, cursor state, emergency-stop hook)
- `main.py` gains `harvest-messages`, `backfill-beeper`, `score-interactions` subcommands so launchd plists have a real target; `cmd_followup` now loads `contact_kpis.json` when present
- FollowUp scoring integrates the ContactKPI bonus per `docs/patches/followup-scorer-beeper.md` — additive bonus capped `[-20, +40]`, gracefully falls back to pre-Beeper scoring when the harvester hasn't run
- `install-launchd.sh` hardened: dry-run default, pre-flight validation, newsyslog.d log rotation, explicit `--apply` / `--uninstall` flags
- `/signals` 2nd-dismiss bug fixed via optimistic update (#143)

Closes #143. Advances #149 / #150. Sprint 3.33 S2 per meta-issue #152.

## Test plan
- [x] `python -m harvester.beeper_client` — offline self-test passes (normalization, URL construction, handle classification)
- [x] `python -m harvester.pipeline` — offline self-test passes (basic run, intra+cross-run dedup, pause flag, cursor advance, reader crash isolation)
- [x] `python main.py score-interactions` — runs on empty data without error
- [x] `python main.py` help text lists the three new subcommands
- [x] `./scripts/install-launchd.sh` dry-run shows plan without mutations
- [x] `followup_scorer.score_contacts()` produces identical totals with `contact_kpis={}` vs pre-patch; adds +25 when KPI has `awaiting=mine + multichannel`
- [x] `pnpm build` on dashboard succeeds
- [ ] Manual prod check on `/signals` after deploy: click Dismiss twice on same contact — first dismisses optimistically, contact leaves Candidates instantly, 2nd click targets are gone (no "silent no-op" window)
- [ ] Monthly launchd plist runs `crm-sync --include-omnichannel` — exercised in Session 3 once dry-run biography patch lands

## Notes for merging
- `./scripts/install-launchd.sh --apply` is a separate **manual step** on the Mac after this merges — agents won't load automatically. Run it (and expect a sudo prompt for newsyslog.d) before the next hourly cadence is expected to fire.
- `contact_kpis.json` doesn't exist yet; scoring falls back cleanly. First real KPI file appears after the first `harvest-messages --incremental` + `score-interactions` pair runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)