### PR TITLE
Sprint 3.33 S3: biography omnichannel dry-run ready + merge bug fix

### DIFF
--- a/crm_sync.py
+++ b/crm_sync.py
@@ -4,21 +4,45 @@ CRM Sync — sync CRM notes and tags from dashboard to Google Contacts.
 Reads crm_state.json from GCS/local data dir and:
   1. Writes CRM notes to Google Contacts biographies (marker block pattern)
   2. Syncs CRM tags to Google Contacts groups (additive only, never removes)
+  3. (Opt-in via ENABLE_OMNICHANNEL_WRITEBACK) writes a metadata-only
+     Omnichannel block summarizing multi-channel contact activity into
+     the same biography. Zero message content per
+     docs/schemas/interaction.md §Privacy defaults.
 
 Uses the same marker block pattern as interaction_scanner.py and linkedin_scanner.py.
 """
 
 import json
 import logging
+import os
+import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
-from config import DATA_DIR
+from config import (
+    DATA_DIR,
+    FOLLOWUP_BEEPER_KPI_FILE,
+    FOLLOWUP_OWN_COMPANY_DOMAINS,
+    FOLLOWUP_OWN_COMPANY_ORG_KEYWORDS,
+)
+from harvester.crm_omnichannel import (
+    backup_biographies,
+    build_block,
+    merge_into_biography,
+    should_update,
+)
+from harvester.scoring_signals import load_kpis_from_json
 
 logger = logging.getLogger("crm_sync")
 
 CRM_NOTE_MARKER = "── CRM Notes"
 CRM_TAG_PREFIX = "CRM:"
+
+# Google People API write rate cap is 60 QPM (documented on the quotas page).
+# We keep a local floor to avoid bursts that can trigger backoff — matches the
+# rollback scripts' convention for Sprint 3.33 S3.
+_PEOPLE_API_MIN_INTERVAL_SECONDS = 1.1
 
 
 def load_crm_state() -> dict:
@@ -245,6 +269,168 @@ def sync_tags(client, crm_state: dict, dry_run: bool = False) -> dict:
     return {"groups_created": groups_created, "memberships_added": memberships_added, "errors": errors}
 
 
+def _is_own_company_contact(contact: dict) -> bool:
+    """Skip own-company (Instarea) teammates' cards from omnichannel writeback.
+
+    Mirrors followup_scorer._is_own_company so the same set of contacts
+    that are excluded from lead scoring are also excluded from biography
+    writebacks. Peter's colleagues don't need Beeper rollups on their
+    Google Contacts cards.
+    """
+    orgs = contact.get("organizations", []) or []
+    org_name = (orgs[0].get("name", "") if orgs else "").lower()
+    if any(kw in org_name for kw in FOLLOWUP_OWN_COMPANY_ORG_KEYWORDS):
+        return True
+    emails = {
+        (e.get("value") or "").lower()
+        for e in (contact.get("emailAddresses") or [])
+    }
+    for email in emails:
+        if "@" in email:
+            domain = email.split("@")[-1]
+            if domain in FOLLOWUP_OWN_COMPANY_DOMAINS:
+                return True
+    return False
+
+
+def sync_omnichannel(
+    client,
+    *,
+    dry_run: bool = False,
+    backup_dir: Optional[Path] = None,
+    kpi_path: Optional[Path] = None,
+) -> dict:
+    """Sync ContactKPI rollups into Google Contacts biographies.
+
+    Reads data/interactions/contact_kpis.json (written by
+    `python main.py score-interactions`), renders a fenced Omnichannel
+    block per contact via `harvester.crm_omnichannel.build_block`,
+    merges into the existing biography, writes back via People API
+    with diff-based skip.
+
+    Gates:
+      - `ENABLE_OMNICHANNEL_WRITEBACK` env var must be truthy — default off
+        during Sprint 3.33 S3 dry-run phase, flipped after first clean run.
+      - Skips own-company contacts (matches followup_scorer convention).
+      - Writes a backup of every touched biography to `backup_dir` BEFORE
+        any API call — the global deletion policy requires reversibility.
+      - Rate-limited to Google People API's 60 QPM ceiling.
+      - Privacy red line: `build_block` is metadata-only; no message text
+        can reach the biography even if the KPI file is poisoned.
+
+    Returns a result dict with per-status counts and the backup path.
+    """
+    if not os.getenv("ENABLE_OMNICHANNEL_WRITEBACK", "").lower() in ("1", "true", "yes"):
+        logger.info("sync_omnichannel: disabled (ENABLE_OMNICHANNEL_WRITEBACK not truthy)")
+        return {"status": "disabled", "synced": 0, "skipped_no_kpi": 0,
+                "skipped_own_co": 0, "skipped_no_change": 0, "errors": 0}
+
+    kpi_path = kpi_path or FOLLOWUP_BEEPER_KPI_FILE
+    kpis = load_kpis_from_json(kpi_path)
+    if not kpis:
+        logger.info(
+            "sync_omnichannel: no ContactKPI data at %s — nothing to write",
+            kpi_path,
+        )
+        return {"status": "empty", "synced": 0, "skipped_no_kpi": 0,
+                "skipped_own_co": 0, "skipped_no_change": 0, "errors": 0}
+
+    if backup_dir is None:
+        backup_dir = DATA_DIR / "biography_backups"
+    date_stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    time_stamp = datetime.now(timezone.utc).strftime("%H%M%S")
+    backup_path = backup_dir / f"biographies_{date_stamp}_{time_stamp}.json"
+
+    stats = {
+        "status": "ok",
+        "synced": 0,
+        "skipped_no_kpi": 0,
+        "skipped_own_co": 0,
+        "skipped_no_change": 0,
+        "errors": 0,
+    }
+
+    # Fetch + backup biographies BEFORE any write. We pull contacts in a
+    # single pass (each get_contact is ~150ms + rate limit) so the backup
+    # file reflects the exact state we're about to mutate — no TOCTOU window.
+    logger.info(
+        "sync_omnichannel: %d contacts have KPI data; fetching biographies "
+        "(rate-limited to %.1fs between calls)…",
+        len(kpis), _PEOPLE_API_MIN_INTERVAL_SECONDS,
+    )
+    contacts_by_rn: dict[str, dict] = {}
+    last_call = 0.0
+    for rn in list(kpis.keys()):
+        elapsed = time.monotonic() - last_call
+        if elapsed < _PEOPLE_API_MIN_INTERVAL_SECONDS:
+            time.sleep(_PEOPLE_API_MIN_INTERVAL_SECONDS - elapsed)
+        last_call = time.monotonic()
+        try:
+            person = client.get_contact(
+                rn,
+                person_fields="biographies,metadata,names,emailAddresses,organizations",
+            )
+            contacts_by_rn[rn] = person
+        except Exception as e:
+            logger.warning("sync_omnichannel: fetch failed for %s: %s", rn, e)
+            stats["errors"] += 1
+
+    backup_biographies(
+        list(contacts_by_rn.values()),
+        backup_path,
+        note="pre sync_omnichannel",
+    )
+    logger.info("sync_omnichannel: backup written → %s", backup_path)
+
+    # Second pass: per-contact diff + write.
+    last_write = 0.0
+    for rn, kpi in kpis.items():
+        contact = contacts_by_rn.get(rn)
+        if not contact:
+            stats["skipped_no_kpi"] += 1
+            continue
+
+        if _is_own_company_contact(contact):
+            stats["skipped_own_co"] += 1
+            continue
+
+        try:
+            bios = contact.get("biographies", []) or []
+            existing_bio = bios[0].get("value", "") if bios else ""
+            etag = contact.get("etag", "")
+
+            new_block = build_block(kpi)
+            if not should_update(existing_bio, new_block):
+                stats["skipped_no_change"] += 1
+                continue
+
+            new_bio = merge_into_biography(existing_bio, new_block)
+
+            if dry_run:
+                stats["synced"] += 1  # "would sync"
+                logger.info("  [DRY RUN] sync_omnichannel → %s", rn)
+                continue
+
+            # Rate-limit write calls separately from fetch — both paths hit
+            # the same 60 QPM bucket.
+            elapsed = time.monotonic() - last_write
+            if elapsed < _PEOPLE_API_MIN_INTERVAL_SECONDS:
+                time.sleep(_PEOPLE_API_MIN_INTERVAL_SECONDS - elapsed)
+            last_write = time.monotonic()
+
+            body = {"biographies": [{"value": new_bio, "contentType": "TEXT_PLAIN"}]}
+            client.update_contact(rn, etag, body, update_fields="biographies")
+            stats["synced"] += 1
+            logger.info("  sync_omnichannel: wrote %s", rn)
+        except Exception as e:
+            logger.warning("sync_omnichannel failed for %s: %s", rn, e)
+            stats["errors"] += 1
+
+    stats["backup"] = str(backup_path)
+    logger.info(f"sync_omnichannel stats: {stats}")
+    return stats
+
+
 def run_crm_sync(client=None, dry_run: bool = False) -> dict:
     """
     Main entry point for CRM sync.
@@ -264,6 +450,7 @@ def run_crm_sync(client=None, dry_run: bool = False) -> dict:
     crm_state = load_crm_state()
 
     notes_result = sync_notes(client, crm_state, dry_run=dry_run)
+    omni_result = sync_omnichannel(client, dry_run=dry_run)
     tags_result = sync_tags(client, crm_state, dry_run=dry_run)
 
     # Save updated state with notesSyncedAt timestamps
@@ -278,5 +465,6 @@ def run_crm_sync(client=None, dry_run: bool = False) -> dict:
 
     return {
         "notes": notes_result,
+        "omnichannel": omni_result,
         "tags": tags_result,
     }

--- a/harvester/crm_omnichannel.py
+++ b/harvester/crm_omnichannel.py
@@ -263,8 +263,29 @@ def strip_block(biography: str) -> str:
 def merge_into_biography(biography: str, block: str) -> str:
     """Produce a new biography with `block` inserted / replacing prior block.
 
-    Insertion position: after the last existing marker block (same rule as
-    crm_sync._insert_crm_block) so user free-text stays at the bottom.
+    Insertion position: after the content of the last existing marker
+    block, before any user free text. Same intent as
+    crm_sync._insert_crm_block but fixes two bugs the original had
+    when multiple implicit-end blocks are stacked (Sprint 3.33 S3
+    dry-run revealed this against Norbert Nepela's biography, which
+    has Last Interaction + Social Signals without explicit End markers):
+
+    1. The old `in_block = not in_block and ...` toggle collapsed on the
+       second marker (True→False), so all content after it fell outside
+       the block and didn't advance `last_marker_line`. Insertion then
+       landed right after the second header, splitting its block.
+    2. Blank lines need to close implicit-end blocks so user free text
+       below the last block doesn't get swallowed into the block's
+       content span.
+
+    Rules applied here:
+    - Any marker line `── X ──` opens a block (unless it's `── End X ──`
+      which closes one). Previous block is implicitly closed.
+    - A blank line within an implicit-end block closes it — content
+      after the blank is treated as user free text (or the start of the
+      next block, detected on the next marker).
+    - `last_marker_line` tracks the last line we're confident belongs to
+      a marker block's content; insertion goes right after it.
     """
     base = strip_block(biography)
 
@@ -277,16 +298,18 @@ def merge_into_biography(biography: str, block: str) -> str:
     for i, line in enumerate(lines):
         s = line.strip()
         if s.startswith("──"):
-            # A marker header line (or an end marker like "── End X ──").
-            # Track as the last-seen marker line regardless of role.
             last_marker_line = i
-            in_block = not in_block and "End" not in s
+            # "── End X ──" closes the block; any other `── X ──` header
+            # opens a new block (and implicitly closes any prior one).
+            in_block = "End" not in s
         elif in_block:
-            # Content line within a marker block counts as part of it.
-            last_marker_line = i
-        elif s.startswith("──") is False and last_marker_line >= 0 and in_block:
-            # Non-marker line within a block
-            last_marker_line = i
+            if not s:
+                # Blank inside an implicit-end block = end-of-block.
+                # Don't advance past it — lines below belong to user free
+                # text (or the next marker, which re-opens on its own).
+                in_block = False
+            else:
+                last_marker_line = i
 
     if last_marker_line >= 0:
         before = "\n".join(lines[: last_marker_line + 1])

--- a/main.py
+++ b/main.py
@@ -1514,10 +1514,18 @@ def cmd_crm_sync(dry_run=False):
         print("ℹ️  DRY RUN — no contacts or groups will be updated")
         print()
 
+    # Operator clarity — echo env gate for the omnichannel pass so it's
+    # obvious whether the Beeper block will actually be written, without
+    # needing to read the crm_sync source.
+    if not os.getenv("ENABLE_OMNICHANNEL_WRITEBACK"):
+        print("ℹ️  Omnichannel writeback: skipped (ENABLE_OMNICHANNEL_WRITEBACK not set)")
+        print()
+
     result = run_crm_sync(dry_run=dry_run)
 
     notes = result["notes"]
     tags = result["tags"]
+    omni = result.get("omnichannel", {})
 
     print()
     print("📝 Notes sync:")
@@ -1525,6 +1533,21 @@ def cmd_crm_sync(dry_run=False):
     print(f"   Skipped (unchanged): {notes['skipped']}")
     if notes["errors"]:
         print(f"   Errors: {notes['errors']}")
+
+    print()
+    print("📨 Omnichannel writeback:")
+    status = omni.get("status", "unknown")
+    print(f"   Status: {status}")
+    if status in ("ok",):
+        print(f"   {'Would sync' if dry_run else 'Synced'}: {omni.get('synced', 0)}")
+        print(f"   Skipped own-company: {omni.get('skipped_own_co', 0)}")
+        print(f"   Skipped no-change:   {omni.get('skipped_no_change', 0)}")
+        if omni.get("skipped_no_kpi"):
+            print(f"   Skipped missing KPI: {omni['skipped_no_kpi']}")
+        if omni.get("errors"):
+            print(f"   Errors: {omni['errors']}")
+        if omni.get("backup"):
+            print(f"   Backup: {omni['backup']}")
 
     print()
     print("🏷️  Tags sync:")

--- a/scripts/restore_biographies.py
+++ b/scripts/restore_biographies.py
@@ -106,6 +106,26 @@ def _classify_api_error(exc: Exception) -> str:
     return "permanent"
 
 
+_PEOPLE_API_MIN_INTERVAL_SECONDS = 1.1
+_last_api_call: list[float] = [0.0]  # mutable singleton — avoid a global `nonlocal`-less closure gotcha
+
+
+def _throttle() -> None:
+    """Sleep enough to keep at or under Google People's 60 QPM write ceiling.
+
+    Each `get_contact`/`update_contact` counts as one quota unit. Without
+    a throttle a bulk restore burns the minute-bucket in ~5 seconds, then
+    blocks for the rest of the minute under server-side backoff that
+    looks like transient errors in our logs. 1.1s interval keeps us at
+    ~55 QPM — under the cap with a safety margin.
+    """
+    import time as _time
+    elapsed = _time.monotonic() - _last_api_call[0]
+    if elapsed < _PEOPLE_API_MIN_INTERVAL_SECONDS:
+        _time.sleep(_PEOPLE_API_MIN_INTERVAL_SECONDS - elapsed)
+    _last_api_call[0] = _time.monotonic()
+
+
 def restore_one(
     client: PeopleAPIClient,
     rn: str,
@@ -120,6 +140,7 @@ def restore_one(
     whole run — silently proceeding through auth failures would produce
     thousands of misleading "skipped" rows.
     """
+    _throttle()
     try:
         person = client.get_contact(rn, person_fields="biographies,metadata")
     except Exception as e:
@@ -150,6 +171,7 @@ def restore_one(
     if dry_run:
         return f"would-change (current={len(current)}c → new={len(new_bio)}c)"
 
+    _throttle()
     body = {"biographies": [{"value": new_bio, "contentType": "TEXT_PLAIN"}]}
     client.update_contact(rn, etag, body, update_fields="biographies")
     return "restored"

--- a/scripts/strip_omnichannel_blocks.py
+++ b/scripts/strip_omnichannel_blocks.py
@@ -69,10 +69,26 @@ def _classify_api_error(exc: Exception) -> str:
     return "permanent"
 
 
+_PEOPLE_API_MIN_INTERVAL_SECONDS = 1.1
+_last_api_call: list[float] = [0.0]
+
+
+def _throttle() -> None:
+    """Hold to ≤55 QPM — Google People's write cap is 60 QPM and server-side
+    backoff when we exceed it surfaces as transient errors that conflate
+    with real failures. Mirrors `scripts/restore_biographies.py`."""
+    import time as _time
+    elapsed = _time.monotonic() - _last_api_call[0]
+    if elapsed < _PEOPLE_API_MIN_INTERVAL_SECONDS:
+        _time.sleep(_PEOPLE_API_MIN_INTERVAL_SECONDS - elapsed)
+    _last_api_call[0] = _time.monotonic()
+
+
 def strip_one(
     client: PeopleAPIClient, rn: str, *, dry_run: bool,
 ) -> str:
     """Process one contact. Returns status string for aggregation."""
+    _throttle()
     try:
         person = client.get_contact(rn, person_fields="biographies,metadata")
     except Exception as e:
@@ -96,6 +112,7 @@ def strip_one(
     if dry_run:
         return f"would-strip (len {len(current)} → {len(new_bio)})"
 
+    _throttle()
     etag = person.get("etag")
     body = {"biographies": [{"value": new_bio, "contentType": "TEXT_PLAIN"}]}
     client.update_contact(rn, etag, body, update_fields="biographies")


### PR DESCRIPTION
## Summary

Session 3 of Sprint 3.33 (per \`docs/patches/crm-sync-omnichannel.md\` + \`memory/v3.33-plan.md\`). Biography writeback plumbed end-to-end, gated off by default (\`ENABLE_OMNICHANNEL_WRITEBACK\` env var). Dry-run verified against real contacts; a real merge bug surfaced and fixed.

## What's in

**\`crm_sync.py\` — new \`sync_omnichannel()\`**
- Reads \`data/interactions/contact_kpis.json\` (harvester output)
- Pre-fetches every targeted biography + writes a full backup to \`data/biography_backups/biographies_YYYY-MM-DD_HHMMSS.json\` **before any API write** — reversibility is the global deletion policy
- Renders \`harvester.crm_omnichannel.build_block(kpi)\` → metadata-only block capped at 250 chars (no message content — schema privacy red line)
- Merges via \`merge_into_biography\` → diff-checks via \`should_update\` → People API write with etag
- Skips own-company (Instarea) teammates
- Rate-limited to ≤55 QPM on both fetch + write, matching Google People's 60 QPM ceiling

**\`main.py cmd_crm_sync\`** — surfaces the new pass in CLI output, echoes env-gate status for operator clarity.

**\`scripts/restore_biographies.py\` + \`strip_omnichannel_blocks.py\`** — deferred #151 rate-limiter rolled in. Both scripts now throttle so bulk rollbacks don't burn the minute-bucket.

**\`harvester/crm_omnichannel.py merge_into_biography\` — real bug fixed**
The first dry-run against Norbert Nepela's real biography (Last Interaction + Social Signals, no explicit End markers) surfaced that the state machine toggled \`in_block\` on every marker, collapsing to False on the second header. Result: the Omnichannel block was being inserted **inside** the Social Signals block, splitting its body. Two rule changes fix it:
- Any \`── X ──\` header (non-End) opens a block, implicitly closing any previous one
- A blank line inside an implicit-end block closes it, so user free text below doesn't get swallowed

Self-tests pass; re-render verified on both real contacts.

## Dry-run results

Only 2 contacts have KPI data today — both harvested via the MCP session runner in Session 2:

| resourceName | Channel | 30d msgs | Awaiting | Block placement |
|---|---|---|---|---|
| Peter Čapkovič | Slack | 3 (1 in / 2 out) | their reply (5d) | Appended after Last Interaction ✓ |
| Norbert Nepela | WhatsApp | 2 (1 in / 1 out) | their reply (0d) | Between Social Signals content and user free text ✓ |

Expected: \`would-sync: 2, skipped-own-co: 0, skipped-no-change: 0\`. Matches.

Backup file from the latest dry-run: \`data/biography_backups/biographies_2026-04-21_114643.json\` (2 biographies).

## Not in scope / follow-up

- **LinkedIn vanity-handle matching still limited** — Kristína, Miloslava, Waleed, Adil, Marian DMs landed as unmatched in Session 2's harvest because Google Contacts backup doesn't index LinkedIn vanity URLs on those records. Tracked separately; orthogonal to the biography pass.
- **Sprint 3.33 S3 plan called for inspecting Kristína/Miloslava/Badr/Franklin/family** — those contacts are not in the current KPI file so they weren't exercised. When a future harvest matches them, the same code path fires; no code change needed.
- **Live flip decision** is yours — the patch is default-off. Flip by adding \`--update-env-vars ENABLE_OMNICHANNEL_WRITEBACK=true\` to the Cloud Run Job (or set it locally for a manual run).

## Test plan

- [x] \`python -m harvester.crm_omnichannel\` → all self-tests pass (including strip + merge + backup round-trip)
- [x] \`ENABLE_OMNICHANNEL_WRITEBACK=true python main.py crm-sync --dry-run\` → clean, 2 would-sync, backup written
- [x] Re-render verified for both contacts — block placement correct, no block-splitting regression
- [x] Rate-limiter: eyeballed 1.1s interval between \`get_contact\` calls during dry-run (~2.2s total for 2 fetches matches)
- [x] Own-company filter: traced through locally — Instarea contacts would be skipped (no Instarea contact has KPI data today to test on real)
- [ ] (After merge) one live write on a single hand-picked contact to validate the roll-forward path end-to-end — do this with \`--yes\` on \`restore_biographies.py\` standing by
- [ ] (Optional) full-book dry-run once a future harvest populates more KPI entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)