### PR TITLE
Fix: surface Beeper-only contacts on /crm + /followup (#162)

### DIFF
--- a/followup_scorer.py
+++ b/followup_scorer.py
@@ -302,13 +302,33 @@ def score_contacts(
     contacts_by_rn = {c.get("resourceName", ""): c for c in contacts}
     candidates: list[FollowUpScore] = []
 
-    for rn, emails in contact_emails.items():
+    # Iterate the UNION of contacts with email history AND contacts with
+    # Beeper KPIs. Previously we only iterated `contact_emails.items()`, so a
+    # Slack/WhatsApp/LinkedIn-DM-only contact with live Beeper activity but
+    # no Gmail/Calendar touchpoint never entered the scoring loop — making
+    # them invisible on /crm and /followup no matter how hot the chat thread
+    # was. See #162.
+    all_resource_names = set(contact_emails.keys()) | set(contact_kpis.keys())
+
+    for rn in all_resource_names:
+        emails = contact_emails.get(rn, set())
         last_date, interaction_count = _get_last_activity(rn, emails, interactions)
         li_signal = linkedin_signals.get(rn, {})
         li_type = li_signal.get("signal_type")
         is_job_change = _is_valid_job_change(li_signal)
         if li_type == "job_change" and not is_job_change:
             li_type = "profile"  # downgrade junk job_change to profile-only
+
+        # A Beeper KPI with actual 30d activity is a bypass signal — equivalent
+        # to a LinkedIn job_change in that it surfaces a contact who would
+        # otherwise be filtered out for having no recent email/meeting
+        # touchpoint. Without this, the iteration above would still skip them
+        # at the min_months / min_interactions / max_age gates below.
+        kpi_probe = contact_kpis.get(rn)
+        w30 = kpi_probe.windows.get("30d") if kpi_probe else None
+        has_active_beeper = bool(
+            w30 and (w30.messages_in + w30.messages_out) > 0
+        )
 
         # Calculate months gap
         if last_date:
@@ -318,20 +338,24 @@ def score_contacts(
             except ValueError:
                 months_gap = 0.0
         else:
-            # No interaction history — only surface if job_change
+            # No email/calendar history — only surface if job_change OR if
+            # Beeper shows real cross-channel activity we'd otherwise miss.
             months_gap = 0.0
-            if not is_job_change:
+            if not is_job_change and not has_active_beeper:
                 continue
 
-        # Filter: min_months and min_interactions (bypassed for job_change)
-        if not is_job_change:
+        # Filter: min_months and min_interactions (bypassed for job_change
+        # OR for contacts with live Beeper activity)
+        if not is_job_change and not has_active_beeper:
             if last_date and months_gap < min_months:
                 continue
             if interaction_count < min_interactions:
                 continue
 
-        # Filter: drop very-old-only contacts (5+ years silent) unless LinkedIn job_change
-        if not is_job_change and last_date and months_gap > FOLLOWUP_MAX_AGE_MONTHS:
+        # Filter: drop very-old-only contacts (5+ years silent) unless they
+        # have a LinkedIn job_change OR a live Beeper thread
+        if (not is_job_change and not has_active_beeper
+                and last_date and months_gap > FOLLOWUP_MAX_AGE_MONTHS):
             continue
 
         # Extract contact info


### PR DESCRIPTION
## Summary

Closes #162. Shipping the 5-line iteration fix surfaced during Sprint 3.33 S3 verification: Beeper-only contacts now appear in followup scoring (and thus on \`/crm\`, \`/followup\`) even without Gmail/Calendar history.

## The gap this closes

From the Sprint 3.33 S3 verification I just ran on prod:
- Peter Čapkovič (Slack-only colleague, in Peter's contact_kpis after Session 2's MCP harvest): **invisible on /crm**. No email history → never entered \`score_contacts\`' iteration → no score computed → not in followup_scores.json → nothing for \`/api/crm\` to return.
- Norbert Nepela (WhatsApp + email history): visible, but without Beeper bonus applied (score_breakdown.beeper was null) because prod's followup_scores.json is from 2026-04-19, before the Beeper patch shipped.

The first case is blocking the sprint's headline value: "recent business conversations from Beeper should elevate contacts on /crm".

## Change

Two coupled changes, same reason:
1. Iterate \`set(contact_emails.keys()) | set(contact_kpis.keys())\` so Beeper-only contacts enter the loop.
2. Treat \`has_active_beeper\` (any 30d message) as a bypass signal parallel to LinkedIn job_change — skips the min_months / min_interactions / max_age gates that would drop a Beeper-only contact for having no recent email touchpoint.

Both are additive. Contacts with email history follow the exact same path as before.

## Local verification

With current \`contact_kpis.json\` (Čapkovič + Norbert) + stale email cache:
\`\`\`
total scored: 93 (was 92)
  rank   1 · Norbert Nepela   · score  58.0 · beeper=+5.0 · awaiting=theirs · ch=whatsapp
  rank  93 · Peter Capkovic   · score  11.0 · beeper=+5.0 · awaiting=theirs · ch=slack
\`\`\`
Čapkovič appears for the first time. Norbert moves from rank 7 (pre-bonus) to rank 1.

## Downstream safety

Checked every helper called with an empty email set:
- \`_get_last_activity(rn, set(), interactions)\` → \`(None, 0)\` — no KeyError
- \`_is_likely_personal(…, emails=set())\` → short-circuits on \`has_org or has_linkedin_url or title\` before the empty-set \`all()\` trap
- \`_is_own_company(org, set())\` → domain check vacuous; org-keyword match still fires
- Unnamed contact skip still works

## Test plan

- [x] Local re-score with Čapkovič + Norbert — both visible, bonuses correct
- [x] Local re-score without \`contact_kpis\` → identical output to pre-patch (no regression for pre-existing contacts)
- [ ] After merge: flip env \`ENABLE_OMNICHANNEL_WRITEBACK=true\` on Cloud Run, let one monthly run regenerate followup_scores.json + biographies, verify Čapkovič/Norbert surface + their biographies get the Omnichannel block
- [ ] Visual spot-check /crm after next prod deploy

## Not in scope

- LinkedIn Matrix-bridge ID matching (separate concern, #158)
- Dashboard Beeper badge surface (follow-up per #158)
- Tuning the relative weight of Beeper bonus vs LinkedIn job_change (product decision — let's watch ranks after first full Cloud Run score regen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)