### PR TITLE
Sprint 3.34 S1: surface Beeper omnichannel on /crm + /signals + harvest chip (#158)

### DIFF
--- a/dashboard/app/components/CRMCard.vue
+++ b/dashboard/app/components/CRMCard.vue
@@ -16,6 +16,27 @@ function signalColor(type: string | undefined): string {
   return 'text-neutral-500 bg-neutral-800'
 }
 
+// Map the harvester's channel tags (docs/schemas/interaction.md) to short
+// UI abbreviations so the awaiting-reply pill stays card-width-safe.
+const CHANNEL_ABBREV: Record<string, string> = {
+  whatsapp: 'WA',
+  linkedin_dm: 'LI',
+  telegram: 'TG',
+  signal: 'SIG',
+  slack: 'Slack',
+  imessage: 'iMsg',
+  sms: 'SMS',
+  messenger: 'FB',
+  instagram: 'IG',
+  discord: 'Disc',
+  twitter: 'X',
+}
+
+function channelAbbrev(ch: string | null): string {
+  if (!ch) return 'DM'
+  return CHANNEL_ABBREV[ch] || ch.slice(0, 4).toUpperCase()
+}
+
 function dragStart(e: DragEvent) {
   if (!e.dataTransfer) return
   e.dataTransfer.setData('text/plain', props.contact.resourceName)
@@ -49,6 +70,14 @@ function dragStart(e: DragEvent) {
           {{ contact.score_total }}
         </span>
       </div>
+    </div>
+
+    <!-- Awaiting-reply pill: red when I owe them a reply via Beeper DM -->
+    <div v-if="contact.beeper?.awaiting_reply_side === 'mine'" class="mb-1.5">
+      <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-red-400 bg-red-500/15">
+        <UIcon name="i-lucide-reply" class="size-3" />
+        You owe reply · {{ channelAbbrev(contact.beeper.channel_primary) }}
+      </span>
     </div>
 
     <!-- LinkedIn signal badge + signal text -->

--- a/dashboard/app/layouts/default.vue
+++ b/dashboard/app/layouts/default.vue
@@ -1,9 +1,45 @@
 <script setup lang="ts">
+import type { HarvestStatusResponse } from '~/server/utils/types'
+
 const route = useRoute()
 const { user, loggedIn, clear: logout } = useUserSession()
 
 const isDemo = computed(() => !loggedIn.value)
 const sidebarOpen = ref(false)
+
+// Surface harvest freshness on every page — the Option-D session-start
+// pattern is otherwise invisible, and a multi-day gap looks identical to
+// "just ran" from the sidebar.
+const { data: harvest } = useFetch<HarvestStatusResponse>('/api/harvest-status', {
+  default: () => null,
+  // Revalidate when navigating between pages so the chip doesn't go stale.
+  key: 'harvest-status',
+})
+
+const harvestChip = computed(() => {
+  const h = harvest.value
+  if (!h) return null
+  const hrs = h.hoursSinceLastRun
+  const fmt = (hrs: number | null) => {
+    if (hrs === null) return '—'
+    if (hrs < 1) return '<1h'
+    if (hrs < 48) return `${Math.round(hrs)}h`
+    return `${Math.round(hrs / 24)}d`
+  }
+  const styleByStaleness: Record<HarvestStatusResponse['staleness'], { color: string; icon: string }> = {
+    fresh: { color: 'text-green-400 bg-green-500/10 border-green-500/20', icon: 'i-lucide-check-circle-2' },
+    hours: { color: 'text-amber-400 bg-amber-500/10 border-amber-500/20', icon: 'i-lucide-clock' },
+    days: { color: 'text-orange-400 bg-orange-500/10 border-orange-500/20', icon: 'i-lucide-clock' },
+    stale: { color: 'text-red-400 bg-red-500/10 border-red-500/20', icon: 'i-lucide-alert-triangle' },
+    missing: { color: 'text-neutral-500 bg-neutral-800 border-neutral-700', icon: 'i-lucide-minus-circle' },
+  }
+  const s = styleByStaleness[h.staleness]
+  const label = h.staleness === 'missing' ? 'no harvest' : fmt(hrs)
+  const title = h.lastRun
+    ? `Last harvest ${new Date(h.lastRun.timestamp).toLocaleString()} · ${h.lastRun.recordsNew} new records · ${h.last7dRuns} runs in 7d`
+    : 'No harvest runs on file'
+  return { label, title, ...s }
+})
 
 const navItems = [
   { label: 'Status', icon: 'i-lucide-activity', to: '/dashboard' },
@@ -55,15 +91,26 @@ watch(() => route.path, () => {
       :class="sidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'"
     >
       <!-- Header -->
-      <div class="flex items-center gap-2 p-4 border-b border-neutral-800/50">
-        <img src="/favicon.svg" alt="Contact Refiner" class="size-8" />
-        <div class="min-w-0">
-          <p class="text-sm font-semibold text-primary-400 truncate">
-            Mission Control
-          </p>
-          <p class="text-[10px] text-neutral-500 truncate">
-            Contacts Refiner
-          </p>
+      <div class="p-4 border-b border-neutral-800/50 space-y-2">
+        <div class="flex items-center gap-2">
+          <img src="/favicon.svg" alt="Contact Refiner" class="size-8" />
+          <div class="min-w-0">
+            <p class="text-sm font-semibold text-primary-400 truncate">
+              Mission Control
+            </p>
+            <p class="text-[10px] text-neutral-500 truncate">
+              Contacts Refiner
+            </p>
+          </div>
+        </div>
+        <div
+          v-if="harvestChip"
+          class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded border text-[10px] font-medium"
+          :class="harvestChip.color"
+          :title="harvestChip.title"
+        >
+          <UIcon :name="harvestChip.icon" class="size-3" />
+          Harvest · {{ harvestChip.label }}
         </div>
       </div>
 

--- a/dashboard/app/pages/crm.vue
+++ b/dashboard/app/pages/crm.vue
@@ -370,6 +370,24 @@ function signalColor(type: string | undefined): string {
               </p>
             </div>
 
+            <!-- Beeper 30d omnichannel row — aggregates only, per docs/schemas/interaction.md §Privacy -->
+            <div v-if="selectedContact.beeper" class="flex items-center gap-2 text-xs">
+              <UIcon name="i-lucide-message-circle" class="size-3.5 text-neutral-500 shrink-0" />
+              <span class="text-neutral-500">Beeper 30d:</span>
+              <span class="text-neutral-300 tabular-nums">
+                in {{ selectedContact.beeper.messages_30d_in }} / out {{ selectedContact.beeper.messages_30d_out }}
+              </span>
+              <span v-if="selectedContact.beeper.channels_30d" class="text-neutral-500">
+                · {{ selectedContact.beeper.channels_30d }} ch
+              </span>
+              <span v-if="selectedContact.beeper.awaiting_reply_side === 'mine'" class="text-red-400 font-medium">
+                · you owe reply
+              </span>
+              <span v-else-if="selectedContact.beeper.awaiting_reply_side === 'theirs'" class="text-neutral-500">
+                · ball in their court
+              </span>
+            </div>
+
             <!-- Emails -->
             <div v-if="selectedContact.contact.emails?.length">
               <p class="text-xs text-neutral-500 mb-1">Email</p>

--- a/dashboard/app/pages/signals.vue
+++ b/dashboard/app/pages/signals.vue
@@ -54,6 +54,7 @@ const SIGNAL_META: Record<LeadSignalType, { label: string; color: string; icon: 
   it_modernisation: { label: 'AI/MODERN', color: 'bg-purple-500/15 text-purple-300 border-purple-500/30', icon: 'i-lucide-cpu' },
   vibecoding_agentic: { label: 'AGENTIC', color: 'bg-pink-500/15 text-pink-300 border-pink-500/30', icon: 'i-lucide-sparkles' },
   recent_job_change: { label: 'JOB CHANGE', color: 'bg-green-500/15 text-green-300 border-green-500/30', icon: 'i-lucide-arrow-right-left' },
+  dm_awaiting_reply: { label: 'REPLY DUE', color: 'bg-red-500/15 text-red-300 border-red-500/30', icon: 'i-lucide-reply' },
 }
 
 const filterOptions: { value: LeadSignalType | 'all'; label: string }[] = [
@@ -65,6 +66,7 @@ const filterOptions: { value: LeadSignalType | 'all'; label: string }[] = [
   { value: 'it_modernisation', label: 'IT Modernisation' },
   { value: 'vibecoding_agentic', label: 'Agentic / Vibecoding' },
   { value: 'recent_job_change', label: 'Recent Job Change' },
+  { value: 'dm_awaiting_reply', label: 'Awaiting My Reply (DM)' },
 ]
 
 const DISMISSAL_OPTIONS: { value: LeadDismissalReason; label: string }[] = [

--- a/dashboard/server/api/harvest-status.get.ts
+++ b/dashboard/server/api/harvest-status.get.ts
@@ -1,25 +1,11 @@
 import { getHarvestRuns } from '../utils/gcs'
 import { isDemoMode } from '../utils/demo'
+import type { HarvestStatusResponse } from '../utils/types'
 
 // Read by the CRM / operator dashboards to answer "when did the harvest last
 // run, and is the data fresh enough to trust?" Without this surface the
 // Option-D session-start pattern is invisible — a 3-week gap looks identical
 // to "just ran, nothing new" from the outside.
-
-export interface HarvestStatusResponse {
-  lastRun: {
-    timestamp: string
-    mode: string
-    chats: number
-    recordsNew: number
-    uploadStatus: string
-    errors: string[]
-  } | null
-  staleness: 'fresh' | 'hours' | 'days' | 'stale' | 'missing'
-  hoursSinceLastRun: number | null
-  last7dRuns: number
-  recentErrors: number
-}
 
 function classifyStaleness(hours: number | null): HarvestStatusResponse['staleness'] {
   if (hours === null) return 'missing'
@@ -33,7 +19,23 @@ export default defineEventHandler(async (event): Promise<HarvestStatusResponse> 
   // Non-PII aggregates only — fine to expose even in demo mode.
   await isDemoMode(event)
 
-  const { runs } = await getHarvestRuns()
+  // GCS fetch can fail for benign reasons (expired SA key in local dev, a
+  // transient 5xx in prod). The sidebar chip is a read-only observability
+  // surface — a 500 here breaks the entire layout for a nice-to-have signal.
+  // Degrade to 'missing' instead; the chip just shows neutral grey.
+  let runs: Awaited<ReturnType<typeof getHarvestRuns>>['runs'] = []
+  try {
+    ({ runs } = await getHarvestRuns())
+  } catch {
+    return {
+      lastRun: null,
+      staleness: 'missing',
+      hoursSinceLastRun: null,
+      last7dRuns: 0,
+      recentErrors: 0,
+    }
+  }
+
   if (!runs.length) {
     return {
       lastRun: null,

--- a/dashboard/server/utils/lead-signals.ts
+++ b/dashboard/server/utils/lead-signals.ts
@@ -64,6 +64,11 @@ export function deriveSignalTypes(score: FollowUpScore): LeadSignalType[] {
   if (containsAny(roleText + ' ' + headline, IT_MODERNISATION_KEYWORDS)) types.push('it_modernisation')
   if (containsAny(headline, VIBECODING_KEYWORDS)) types.push('vibecoding_agentic')
 
+  // Beeper-derived signal: a warm lead where Peter hasn't replied yet has
+  // higher outreach urgency than a cold profile match — surface it so the
+  // /signals "Action" column can flag it independently of LinkedIn state.
+  if (score.beeper?.awaiting_reply_side === 'mine') types.push('dm_awaiting_reply')
+
   return Array.from(new Set(types))
 }
 

--- a/dashboard/server/utils/types.ts
+++ b/dashboard/server/utils/types.ts
@@ -500,6 +500,23 @@ export interface LICRMResponse {
   }
 }
 
+// --- Harvest status ---
+
+export interface HarvestStatusResponse {
+  lastRun: {
+    timestamp: string
+    mode: string
+    chats: number
+    recordsNew: number
+    uploadStatus: string
+    errors: string[]
+  } | null
+  staleness: 'fresh' | 'hours' | 'days' | 'stale' | 'missing'
+  hoursSinceLastRun: number | null
+  last7dRuns: number
+  recentErrors: number
+}
+
 // --- Lead Signals ---
 
 export type LeadSignalType =
@@ -510,6 +527,7 @@ export type LeadSignalType =
   | 'it_modernisation'
   | 'vibecoding_agentic'
   | 'recent_job_change'
+  | 'dm_awaiting_reply'
 
 export type LeadSignalStage = 'candidate' | 'accepted' | 'dismissed'
 


### PR DESCRIPTION
## Summary

First four dashboard surfaces for #158 — the Sprint 3.33 harvester kernel + ContactKPI scoring is now visible on /crm, /signals, and every page via the sidebar.

- **CRMCard.vue**: red \"You owe reply · {channel}\" pill when \`beeper.awaiting_reply_side === 'mine'\`. Channel abbreviation table covers WA/LI/TG/SIG/Slack/iMsg/SMS/FB/IG/Disc/X.
- **crm.vue detail slide-over**: Beeper 30d row (\`in N / out M · channels · you owe reply | ball in their court\`) — aggregates only, no content, per docs/schemas/interaction.md §Privacy.
- **/signals**: new \`dm_awaiting_reply\` signal type with red REPLY DUE badge + filter option. Derived in \`deriveSignalTypes\` from \`FollowUpScore.beeper\`.
- **default.vue sidebar**: \"Harvest · {Nh|Nd|no harvest}\" chip reading \`/api/harvest-status\`, green/amber/orange/red by staleness.

Additionally hardened \`/api/harvest-status\` to catch GCS fetch errors and degrade to \`'missing'\` rather than 500-ing the sidebar — an expired SA key (local dev) or transient GCS 5xx would otherwise break the entire layout. Also moved \`HarvestStatusResponse\` to \`server/utils/types.ts\` for consistency with the other \`*Response\` types.

Meta-issue: #164 · Closes (partially): #158

## Test plan

- [x] \`pnpm build\` passes
- [x] Local dev: harvest chip renders as \"Harvest · no harvest\" (expected — no GCS creds locally)
- [ ] After merge + Render deploy: visit /crm — confirm harvest chip shows green/amber with real staleness
- [ ] After next monthly Cloud Run Job (or force-run): confirm at least one contact surfaces with the red \"You owe reply\" pill on the CRM kanban
- [ ] /signals → filter by \"Awaiting My Reply (DM)\" — confirm the new signal type appears when harvest data has \`awaiting_reply_side === 'mine'\`
- [ ] Open CRM detail slide-over on a Beeper-enriched contact — confirm Beeper 30d row renders with correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)