### PR TITLE
fix(docker): bundle harvester/ into Cloud Run image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY *.py instructions.md ./
 COPY code_tables/ code_tables/
 
+# harvester/ is a PEP 420 namespace package (no __init__.py) that followup_scorer
+# and crm_sync import from. Missed by `COPY *.py` — shipped empty in 3.33, which
+# made Phase 4 + 5 silently fail with ModuleNotFoundError on every Cloud Run.
+COPY harvester/ harvester/
+
 # Cloud Run Job entry point
 CMD ["python", "entrypoint.py"]


### PR DESCRIPTION
## Summary

**Root cause of silent Phase 4 + 5 failures on every Cloud Run since Sprint 3.33 merged.**

Today's forced monthly run (\`contacts-refiner-z75zf\`, after flipping \`ENABLE_OMNICHANNEL_WRITEBACK=true\`) \"succeeded\" in 1m24s but logs show:

\`\`\`
[ERROR] contacts-refiner: FollowUp scoring failed (non-fatal): No module named 'harvester'
[ERROR] contacts-refiner: CRM sync failed (non-fatal): No module named 'harvester'
\`\`\`

So no biography writeback fired, no followup_scores.json refresh, no CRM sync. The pipeline swallowed both as \"non-fatal\" and exited 0.

## Why

\`Dockerfile:10\` is \`COPY *.py instructions.md ./\` — copies only top-level .py files. \`harvester/\` is a subdirectory so the PEP 420 namespace package never landed in the image. \`followup_scorer.py\` and \`crm_sync.py\` (which ARE copied) both \`from harvester.X import ...\`, hence the ModuleNotFoundError.

## Fix

One line: \`COPY harvester/ harvester/\` after the code_tables copy.

## Impact

Every scheduled Cloud Run Job since 3.33 merged (2026-04-21) has been skipping Phase 4 + 5 silently. Impact is scoped:
- No biography omnichannel blocks ever written to Google Contacts (safe — writeback was behind a flag that just got flipped today)
- \`data/followup_scores.json\` hasn't been regenerated from \`contact_kpis.json\` in cloud (so #162 Čapkovič + Norbert surfacing was running on stale data)
- \`data/crm_state.json\` tags → Google contact groups sync silently skipped

## Test plan

- [ ] Cloud Build auto-deploys on merge (~3min)
- [ ] Force-run: \`gcloud run jobs execute contacts-refiner --region europe-west1 --update-env-vars CADENCE=monthly\`
- [ ] Verify logs show: \`Phase 4: FollowUp Scoring ... success\` and \`Phase 5: CRM Sync ... success\` (no ModuleNotFoundError)
- [ ] Inspect 5 Google Contacts biographies — confirm omnichannel blocks appear and are accurate
- [ ] If bad: \`scripts/restore_biographies.py --omnichannel-only\`

## Follow-ups (non-blocking)

The \"non-fatal\" swallow in \`entrypoint.py\` hid this for weeks. Worth a separate issue: Phase 4+5 import failures should at least be counted in the run summary and emailed digest, not silently swallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)