### PR TITLE
fix(#171): skip legacy resourceName in crm_sync tag-group sync

### DIFF
--- a/crm_sync.py
+++ b/crm_sync.py
@@ -217,14 +217,27 @@ def sync_tags(client, crm_state: dict, dry_run: bool = False) -> dict:
     memberships_added = 0
     errors = 0
 
-    # Collect all unique tags across contacts
+    # Collect all unique tags across contacts. Google People API rejects
+    # "profile-only" resourceNames (bare-digit `people/<digits>`) from
+    # contactGroups.members.modify — only `people/c<digits>` (contactId)
+    # is accepted. Filter them out here so the whole tag-group sync doesn't
+    # 400 on a single bad record. See #171.
     tag_contacts: dict[str, list[str]] = {}  # tag -> [resourceName, ...]
+    skipped_legacy = 0
     for rn, state in contacts.items():
+        if not rn.startswith("people/c"):
+            skipped_legacy += 1
+            continue
         for tag in state.get("tags", []):
             if not tag.strip():
                 continue
             group_name = f"{CRM_TAG_PREFIX}{tag.strip()}"
             tag_contacts.setdefault(group_name, []).append(rn)
+    if skipped_legacy:
+        logger.info(
+            "Skipped %d contacts with legacy (non-c) resourceName from tag sync",
+            skipped_legacy,
+        )
 
     if not tag_contacts:
         logger.info("No CRM tags to sync")


### PR DESCRIPTION
## Summary
- Filters bare-digit `people/<digits>` resourceNames (profile-only records that Google People API rejects from `contactGroups.members.modify`) before the tag-group sync
- Logs a single "Skipped N contacts with legacy (non-c) resourceName" line instead of 4x HTTP 400 warnings

## Why
Monthly run `contacts-refiner-5jqhr` (2026-04-21) bounced 4 of 6 CRM tag-group syncs with:
```
Failed to sync tag group CRM:sa: 400 Resource name "people/4849050051214848524" is not a valid contact person resource.
```
Root cause: the API only accepts `people/c<digits>` (contactId) for group membership ops. CLAUDE.md already notes this pattern but `sync_tags` wasn't enforcing it. Closes #171.

## Test plan
- [x] `git diff` shows a pre-loop filter and a skip-count log
- [ ] Next monthly run: no `Failed to sync tag group` warnings for bare-digit resourceNames
- [ ] `Skipped N contacts with legacy (non-c) resourceName from tag sync` line appears once in logs

## Related
- Broader crm_sync cleanup (drop `CRM:` prefix, alias-aware matching) tracked in #172 — separate PR