### PR TITLE
fix(#172): crm_sync reuses Peter's existing labels (alias + fold + fuzzy)

### DIFF
--- a/config.py
+++ b/config.py
@@ -690,6 +690,20 @@ FOLLOWUP_OWN_COMPANY_DOMAINS = ("instarea.com", "instarea.sk")  # Peter's own �
 FOLLOWUP_OWN_COMPANY_ORG_KEYWORDS = ("instarea",)
 FOLLOWUP_MAX_AGE_MONTHS = 60.0  # Drop contacts whose last interaction is older than 5 years
 
+# ── CRM Tag Sync (#172) ──────────────────────────────────────────────────
+# Controls how crm_sync.sync_tags routes raw CRM tags to Google contact groups.
+# Default (post-#172): reuse Peter's existing bare labels ("IS", "TB", "Ďatelinka")
+# instead of creating parallel CRM:* duplicates. See #172 for full rationale.
+CRM_TAG_USE_PREFIX = os.getenv("CRM_TAG_USE_PREFIX", "false").lower() in ("1", "true", "yes")
+CRM_TAG_PREFIX_STRING = "CRM:"  # only used if CRM_TAG_USE_PREFIX is true
+CRM_TAG_FUZZY_THRESHOLD = 90    # rapidfuzz token_sort_ratio: >= this → reuse existing group
+# Canonical alias map: raw tag (lowercased, ASCII-folded) → existing Google label
+# Extend here as Peter establishes more shorthand conventions.
+CRM_TAG_ALIASES: dict[str, str] = {
+    "instarea": "IS",
+    "datelinka": "Ďatelinka",
+}
+
 # ── Multi-channel Beeper scoring (#150) ─────────────────────────────────────
 # Weights applied to ContactKPI rollups computed by harvester/scoring_signals.py
 # from data/interactions/*.jsonl. See docs/schemas/scoring-signals.md for derivation.

--- a/crm_sync.py
+++ b/crm_sync.py
@@ -22,6 +22,10 @@ from typing import Optional
 
 from config import (
     DATA_DIR,
+    CRM_TAG_ALIASES,
+    CRM_TAG_FUZZY_THRESHOLD,
+    CRM_TAG_PREFIX_STRING,
+    CRM_TAG_USE_PREFIX,
     FOLLOWUP_BEEPER_KPI_FILE,
     FOLLOWUP_OWN_COMPANY_DOMAINS,
     FOLLOWUP_OWN_COMPANY_ORG_KEYWORDS,
@@ -33,11 +37,64 @@ from harvester.crm_omnichannel import (
     should_update,
 )
 from harvester.scoring_signals import load_kpis_from_json
+from unidecode import unidecode
 
 logger = logging.getLogger("crm_sync")
 
 CRM_NOTE_MARKER = "── CRM Notes"
-CRM_TAG_PREFIX = "CRM:"
+CRM_TAG_PREFIX = CRM_TAG_PREFIX_STRING  # back-compat alias for callers that imported the old name
+
+
+def _fold(name: str) -> str:
+    """ASCII-fold + lowercase a label name for diacritic-insensitive matching."""
+    return unidecode(name).strip().lower()
+
+
+def _resolve_tag_to_group_name(
+    raw_tag: str,
+    existing_names: list[str],
+) -> tuple[str, str]:
+    """Map a raw CRM tag to the Google contact group name to use.
+
+    Resolution order (first match wins):
+      1. Explicit alias (`CRM_TAG_ALIASES[fold(raw)]`) — honours Peter's shorthand.
+      2. Exact match on existing group name — case/diacritic-insensitive.
+      3. Fuzzy match against existing group names (rapidfuzz token_sort_ratio).
+      4. Fallback: create a new group (prefixed if `CRM_TAG_USE_PREFIX`, else bare).
+
+    Returns (group_name, route) where `route` names which rule fired
+    (for logging).
+    """
+    raw = raw_tag.strip()
+    folded = _fold(raw)
+
+    # 1. Alias
+    if folded in CRM_TAG_ALIASES:
+        return CRM_TAG_ALIASES[folded], "alias"
+
+    # 2. Exact (case/diacritic-insensitive) match against Peter's existing labels
+    for name in existing_names:
+        if _fold(name) == folded:
+            return name, "fold-exact"
+
+    # 3. Fuzzy — rapidfuzz is already a project dependency (followup scorer).
+    try:
+        from rapidfuzz import fuzz, process
+    except ImportError:
+        fuzz = process = None  # type: ignore[assignment]
+    if process is not None and existing_names:
+        match = process.extractOne(
+            folded,
+            [_fold(n) for n in existing_names],
+            scorer=fuzz.token_sort_ratio,
+        )
+        if match and match[1] >= CRM_TAG_FUZZY_THRESHOLD:
+            return existing_names[match[2]], f"fuzzy@{int(match[1])}"
+
+    # 4. Create fresh — bare by default (#172), prefixed only if env flag set
+    if CRM_TAG_USE_PREFIX:
+        return f"{CRM_TAG_PREFIX_STRING}{raw}", "create-prefixed"
+    return raw, "create-bare"
 
 # Google People API write rate cap is 60 QPM (documented on the quotas page).
 # We keep a local floor to avoid bursts that can trigger backoff — matches the
@@ -217,37 +274,53 @@ def sync_tags(client, crm_state: dict, dry_run: bool = False) -> dict:
     memberships_added = 0
     errors = 0
 
-    # Collect all unique tags across contacts. Google People API rejects
-    # "profile-only" resourceNames (bare-digit `people/<digits>`) from
-    # contactGroups.members.modify — only `people/c<digits>` (contactId)
-    # is accepted. Filter them out here so the whole tag-group sync doesn't
-    # 400 on a single bad record. See #171.
-    tag_contacts: dict[str, list[str]] = {}  # tag -> [resourceName, ...]
+    # Filter out "profile-only" (bare-digit) resourceNames up front — Google
+    # People API rejects them from contactGroups.members.modify (see #171).
+    filtered: list[tuple[str, list[str]]] = []
     skipped_legacy = 0
+    raw_by_contact: dict[str, list[str]] = {}
     for rn, state in contacts.items():
         if not rn.startswith("people/c"):
             skipped_legacy += 1
             continue
-        for tag in state.get("tags", []):
-            if not tag.strip():
-                continue
-            group_name = f"{CRM_TAG_PREFIX}{tag.strip()}"
-            tag_contacts.setdefault(group_name, []).append(rn)
+        tags = [t.strip() for t in state.get("tags", []) if t.strip()]
+        if tags:
+            raw_by_contact[rn] = tags
     if skipped_legacy:
         logger.info(
             "Skipped %d contacts with legacy (non-c) resourceName from tag sync",
             skipped_legacy,
         )
-
-    if not tag_contacts:
+    if not raw_by_contact:
         logger.info("No CRM tags to sync")
         return {"groups_created": 0, "memberships_added": 0, "errors": 0}
 
-    logger.info("Syncing %d CRM tag groups", len(tag_contacts))
-
-    # Fetch existing groups
+    # Fetch existing groups once so alias/fold/fuzzy resolution has a universe
+    # to match against (user-created groups only — system groups like
+    # "myContacts" aren't candidates).
     existing_groups = client.get_all_contact_groups()
+    user_groups = [
+        g for g in existing_groups
+        if g.get("groupType") in (None, "USER_CONTACT_GROUP")
+    ]
+    existing_names = [g["name"] for g in user_groups]
     group_map = {g["name"]: g["resourceName"] for g in existing_groups}
+
+    # Resolve raw tag → canonical group name (reuse existing labels where
+    # possible, per #172). Cache resolution to keep the log concise.
+    resolve_cache: dict[str, tuple[str, str]] = {}
+    tag_contacts: dict[str, list[str]] = {}
+    for rn, tags in raw_by_contact.items():
+        for raw in tags:
+            if raw not in resolve_cache:
+                resolve_cache[raw] = _resolve_tag_to_group_name(raw, existing_names)
+            group_name, route = resolve_cache[raw]
+            tag_contacts.setdefault(group_name, []).append(rn)
+    for raw, (group_name, route) in sorted(resolve_cache.items()):
+        if raw != group_name:
+            logger.info("  tag %r → %r (%s)", raw, group_name, route)
+
+    logger.info("Syncing %d CRM tag groups", len(tag_contacts))
 
     for group_name, resource_names in tag_contacts.items():
         try:


### PR DESCRIPTION
## Summary
- Replace exact-string tag→group lookup in \`sync_tags\` with a 4-step resolver: alias → fold-exact → fuzzy (rapidfuzz ≥ 90) → fallback
- Fallback creates BARE group names (no \`CRM:\` prefix). Opt-in prefix via \`CRM_TAG_USE_PREFIX\` env flag.
- New \`CRM_TAG_ALIASES\` config map: \`instarea → IS\`, \`datelinka → Ďatelinka\`. Extend as more shorthand conventions establish.
- Per-tag routing decision logged once per run (e.g. \`tag 'instarea' → 'IS' (alias)\`) so drift is diagnostic.

## Why
Closes #172. Sprint 3.34 S2's first clean writeback dropped duplicate \`CRM:Datelinka\` and \`CRM:instarea\` groups because the old code did exact-string match. These dupes collided with Peter's long-established \`Ďatelinka\` (176 members) and \`IS\` (6 members) labels. Duplicates were manually deleted 2026-04-21 (members were already in canonical); this PR prevents the pattern from repeating.

## Verified
Smoke-tested against Peter's real label universe (\`IS\`, \`TB\`, \`VUB\`, \`Ďatelinka\`, \`LTNS\`, \`FollowUp\`, \`Y2026\`, \`ČSOB\`, \`FM UK\`):

| raw tag | resolves to | via |
|---|---|---|
| \`instarea\` | \`IS\` | alias |
| \`datelinka\` | \`Ďatelinka\` | alias |
| \`Ďatelinka\` | \`Ďatelinka\` | alias (fold hits alias-key first) |
| \`ltns\` | \`LTNS\` | fold-exact |
| \`csob\` | \`ČSOB\` | fold-exact |
| \`Y2026\` | \`Y2026\` | fold-exact |
| \`tsh-outreach\` | \`tsh-outreach\` | create-bare |
| \`ksa\` | \`ksa\` | create-bare |

## Test plan
- [x] Resolver smoke test (8 cases)
- [ ] Next monthly run: no new \`CRM:*\` groups created; \`IS\`/\`Ďatelinka\` accumulate new memberships instead
- [ ] Resolution log line appears once per distinct tag in logs

## References
- Root cause discussion in #150 verification thread
- One-time dedup applied 2026-04-21 under Peter auth